### PR TITLE
Ported to work with WiringPi

### DIFF
--- a/librf24-rpi/librf24-WiringPi/Makefile
+++ b/librf24-rpi/librf24-WiringPi/Makefile
@@ -1,0 +1,45 @@
+#############################################################################
+#
+# Makefile for librf24 on Raspberry Pi
+#
+# License: GPL (General Public License)
+# Author:  gnulnulf <arco@appeltaart.mine.nu>
+# Date:    2013/02/07 (version 1.0)
+#
+# Description:
+# ------------
+# use make all and mak install to install the library 
+# You can change the install directory by editing the LIBDIR line
+#
+LIBDIR=/usr/local/lib
+LIBNAME=librf24.so.1.0
+
+
+# The recommended compiler flags for the Raspberry Pi
+CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s -lwiringPi
+
+# make all
+all: librf24
+
+# Make the library
+librf24: RF24.o spi.o
+	g++ -shared -Wl,-soname,librf24.so.1 ${CCFLAGS}  -o ${LIBNAME} spi.o RF24.o
+
+# Library parts
+RF24.o: RF24.cpp
+	g++ -Wall -fPIC ${CCFLAGS} -c RF24.cpp
+
+spi.o: spi.cpp
+	g++ -Wall -fPIC ${CCFLAGS} -c spi.cpp
+
+# clear build files
+clean:
+	rm -rf *o ${LIBNAME}
+
+# Install the library to LIBPATH
+install: 
+	cp librf24.so.1.0 ${LIBDIR}/${LIBNAME}
+	ln -sf ${LIBDIR}/${LIBNAME} ${LIBDIR}/librf24.so.1
+	ln -sf ${LIBDIR}/${LIBNAME} ${LIBDIR}/librf24.so
+	ldconfig
+

--- a/librf24-rpi/librf24-WiringPi/RF24.cpp
+++ b/librf24-rpi/librf24-WiringPi/RF24.cpp
@@ -1,0 +1,1010 @@
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ */
+
+#include "nRF24L01.h"
+#include "RF24_config.h"
+#include "RF24.h"
+
+/****************************************************************************/
+
+void RF24::csn(int mode)
+{
+  // Minimum ideal SPI bus speed is 2x data rate
+  // If we assume 2Mbs data rate and 16Mhz clock, a
+  // divider of 4 is the minimum we want.
+  // CLK:BUS 8Mhz:2Mhz, 16Mhz:4Mhz, or 20Mhz:5Mhz
+#ifdef ARDUINO
+//  spi->setBitOrder(MSBFIRST);
+//  spi->setDataMode(SPI_MODE0);
+//  spi->setClockDivider(SPI_CLOCK_DIV4);
+#endif
+  digitalWrite(csn_pin,mode);
+}
+
+/****************************************************************************/
+
+void RF24::ce(int level)
+{
+  digitalWrite(ce_pin,level);
+}
+
+/****************************************************************************/
+
+uint8_t RF24::read_register(uint8_t reg, uint8_t* buf, uint8_t len)
+{
+  uint8_t status;
+
+  csn(LOW);
+  status = spi->transfer( R_REGISTER | ( REGISTER_MASK & reg ) );
+  while ( len-- )
+    *buf++ = spi->transfer(0xff);
+
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::read_register(uint8_t reg)
+{
+  csn(LOW);
+  spi->transfer( R_REGISTER | ( REGISTER_MASK & reg ) );
+  uint8_t result = spi->transfer(0xff);
+
+  csn(HIGH);
+  return result;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::write_register(uint8_t reg, const uint8_t* buf, uint8_t len)
+{
+  uint8_t status;
+
+  csn(LOW);
+  status = spi->transfer( W_REGISTER | ( REGISTER_MASK & reg ) );
+  while ( len-- )
+    spi->transfer(*buf++);
+
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::write_register(uint8_t reg, uint8_t value)
+{
+  uint8_t status;
+
+  IF_SERIAL_DEBUG(printf_P(PSTR("write_register(%02x,%02x)\r\n"),reg,value));
+
+  csn(LOW);
+  status = spi->transfer( W_REGISTER | ( REGISTER_MASK & reg ) );
+  spi->transfer(value);
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::write_payload(const void* buf, uint8_t len)
+{
+  uint8_t status;
+
+  const uint8_t* current = reinterpret_cast<const uint8_t*>(buf);
+
+  uint8_t data_len = min(len,payload_size);
+  uint8_t blank_len = dynamic_payloads_enabled ? 0 : payload_size - data_len;
+  
+  //printf("[Writing %u bytes %u blanks]",data_len,blank_len);
+  
+  csn(LOW);
+  status = spi->transfer( W_TX_PAYLOAD );
+  while ( data_len-- )
+    spi->transfer(*current++);
+  while ( blank_len-- )
+    spi->transfer(0);
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::read_payload(void* buf, uint8_t len)
+{
+  uint8_t status;
+  uint8_t* current = reinterpret_cast<uint8_t*>(buf);
+
+  uint8_t data_len = min(len,payload_size);
+  uint8_t blank_len = dynamic_payloads_enabled ? 0 : payload_size - data_len;
+  
+  //printf("[Reading %u bytes %u blanks]",data_len,blank_len);
+  
+  csn(LOW);
+  status = spi->transfer( R_RX_PAYLOAD );
+  while ( data_len-- )
+    *current++ = spi->transfer(0xff);
+  while ( blank_len-- )
+    spi->transfer(0xff);
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::flush_rx(void)
+{
+  uint8_t status;
+
+  csn(LOW);
+  status = spi->transfer( FLUSH_RX );
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::flush_tx(void)
+{
+  uint8_t status;
+
+  csn(LOW);
+  status = spi->transfer( FLUSH_TX );
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+uint8_t RF24::get_status(void)
+{
+  uint8_t status;
+
+  csn(LOW);
+  status = spi->transfer( NOP );
+  csn(HIGH);
+
+  return status;
+}
+
+/****************************************************************************/
+
+void RF24::print_status(uint8_t status)
+{
+  printf_P(PSTR("STATUS\t\t = 0x%02x RX_DR=%x TX_DS=%x MAX_RT=%x RX_P_NO=%x TX_FULL=%x\r\n"),
+           status,
+           (status & _BV(RX_DR))?1:0,
+           (status & _BV(TX_DS))?1:0,
+           (status & _BV(MAX_RT))?1:0,
+           ((status >> RX_P_NO) & 0b111),
+           (status & _BV(TX_FULL))?1:0
+          );
+}
+
+/****************************************************************************/
+
+void RF24::print_observe_tx(uint8_t value)
+{
+  printf_P(PSTR("OBSERVE_TX=%02x: POLS_CNT=%x ARC_CNT=%x\r\n"),
+           value,
+           (value >> PLOS_CNT) & 0b1111,
+           (value >> ARC_CNT) & 0b1111
+          );
+}
+
+/****************************************************************************/
+
+void RF24::print_byte_register(const char* name, uint8_t reg, uint8_t qty)
+{
+  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
+  printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
+  while (qty--)
+    printf_P(PSTR(" 0x%02x"),read_register(reg++));
+  printf_P(PSTR("\r\n"));
+}
+
+/****************************************************************************/
+
+void RF24::print_address_register(const char* name, uint8_t reg, uint8_t qty)
+{
+  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
+  printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
+
+  while (qty--)
+  {
+    uint8_t buffer[5];
+    read_register(reg++,buffer,sizeof buffer);
+
+    printf_P(PSTR(" 0x"));
+    uint8_t* bufptr = buffer + sizeof buffer;
+    while( --bufptr >= buffer )
+      printf_P(PSTR("%02x"),*bufptr);
+  }
+
+  printf_P(PSTR("\r\n"));
+}
+
+/****************************************************************************/
+
+RF24::RF24(string _spidevice, uint32_t _spispeed, uint8_t _cepin):
+spidevice( _spidevice) ,spispeed( _spispeed),ce_pin(_cepin), wide_band(true), p_variant(false),
+  payload_size(32), ack_payload_available(false), dynamic_payloads_enabled(false),
+  pipe0_reading_address(0)
+{
+
+}
+/****************************************************************************/
+
+RF24::RF24(uint8_t _cepin, uint8_t _cspin):
+  ce_pin(_cepin), csn_pin(_cspin), wide_band(true), p_variant(false), 
+  payload_size(32), ack_payload_available(false), dynamic_payloads_enabled(false),
+  pipe0_reading_address(0)
+{
+}
+
+/****************************************************************************/
+
+void RF24::setChannel(uint8_t channel)
+{
+  // TODO: This method could take advantage of the 'wide_band' calculation
+  // done in setChannel() to require certain channel spacing.
+
+  const uint8_t max_channel = 127;
+  write_register(RF_CH,min(channel,max_channel));
+}
+
+/****************************************************************************/
+
+void RF24::setPayloadSize(uint8_t size)
+{
+  const uint8_t max_payload_size = 32;
+  payload_size = min(size,max_payload_size);
+}
+
+/****************************************************************************/
+
+uint8_t RF24::getPayloadSize(void)
+{
+  return payload_size;
+}
+
+/****************************************************************************/
+
+static const char rf24_datarate_e_str_0[] PROGMEM = "1MBPS";
+static const char rf24_datarate_e_str_1[] PROGMEM = "2MBPS";
+static const char rf24_datarate_e_str_2[] PROGMEM = "250KBPS";
+static const char * const rf24_datarate_e_str_P[] PROGMEM = {
+  rf24_datarate_e_str_0,
+  rf24_datarate_e_str_1,
+  rf24_datarate_e_str_2,
+};
+static const char rf24_model_e_str_0[] PROGMEM = "nRF24L01";
+static const char rf24_model_e_str_1[] PROGMEM = "nRF24L01+";
+static const char * const rf24_model_e_str_P[] PROGMEM = {
+  rf24_model_e_str_0,
+  rf24_model_e_str_1,
+};
+static const char rf24_crclength_e_str_0[] PROGMEM = "Disabled";
+static const char rf24_crclength_e_str_1[] PROGMEM = "8 bits";
+static const char rf24_crclength_e_str_2[] PROGMEM = "16 bits" ;
+static const char * const rf24_crclength_e_str_P[] PROGMEM = {
+  rf24_crclength_e_str_0,
+  rf24_crclength_e_str_1,
+  rf24_crclength_e_str_2,
+};
+static const char rf24_pa_dbm_e_str_0[] PROGMEM = "PA_MIN";
+static const char rf24_pa_dbm_e_str_1[] PROGMEM = "PA_LOW";
+static const char rf24_pa_dbm_e_str_2[] PROGMEM = "PA_HIGH";
+static const char rf24_pa_dbm_e_str_3[] PROGMEM = "PA_MAX";
+static const char * const rf24_pa_dbm_e_str_P[] PROGMEM = { 
+  rf24_pa_dbm_e_str_0,
+  rf24_pa_dbm_e_str_1,
+  rf24_pa_dbm_e_str_2,
+  rf24_pa_dbm_e_str_3,
+};
+
+void RF24::printDetails(void)
+{
+
+  printf_P(PSTR("SPI device\t = %s\r\n"),spidevice.c_str() );
+  printf_P(PSTR("SPI speed\t = %d\r\n"),spispeed);
+  printf_P(PSTR("CE GPIO\t = %d\r\n"),ce_pin);
+	
+  print_status(get_status());
+
+  print_address_register(PSTR("RX_ADDR_P0-1"),RX_ADDR_P0,2);
+  print_byte_register(PSTR("RX_ADDR_P2-5"),RX_ADDR_P2,4);
+  print_address_register(PSTR("TX_ADDR"),TX_ADDR);
+
+  print_byte_register(PSTR("RX_PW_P0-6"),RX_PW_P0,6);
+  print_byte_register(PSTR("EN_AA"),EN_AA);
+  print_byte_register(PSTR("EN_RXADDR"),EN_RXADDR);
+  print_byte_register(PSTR("RF_CH"),RF_CH);
+  print_byte_register(PSTR("RF_SETUP"),RF_SETUP);
+  print_byte_register(PSTR("CONFIG"),CONFIG);
+  print_byte_register(PSTR("DYNPD/FEATURE"),DYNPD,2);
+
+  printf_P(PSTR("Data Rate\t = %s\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
+  printf_P(PSTR("Model\t\t = %s\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
+  printf_P(PSTR("CRC Length\t = %s\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
+  printf_P(PSTR("PA Power\t = %s\r\n"),pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
+}
+
+/****************************************************************************/
+
+void RF24::begin(int wiringPiMode)
+{
+  // Initialize pins
+  pinMode(ce_pin,OUTPUT);
+
+  if (wiringPiMode == WPI_MODE_PINS) {
+    csn_pin = (spidevice == "/dev/spidev0.1") ? 11 : 10;
+  } else if ((wiringPiMode == WPI_MODE_GPIO) || (wiringPiMode == WPI_MODE_GPIO_SYS)) {
+    csn_pin = (spidevice == "/dev/spidev0.1") ? 7 : 8;
+  } else if (wiringPiMode == WPI_MODE_PHYS) {
+    csn_pin = (spidevice == "/dev/spidev0.1") ? 26 : 24;
+  } else {
+    printf("Error, unrecognized WiringPi pin mapping.");
+    exit(1);
+  }
+
+  pinMode(csn_pin,OUTPUT);
+
+  // Initialize SPI bus
+  //spi->begin();
+spi = new SPI();
+        spi->setdevice(spidevice);
+        spi->setspeed(spispeed);
+        spi->setbits(8);
+        spi->init();
+
+
+  ce(LOW);
+  csn(HIGH);
+
+  // Must allow the radio time to settle else configuration bits will not necessarily stick.
+  // This is actually only required following power up but some settling time also appears to
+  // be required after resets too. For full coverage, we'll always assume the worst.
+  // Enabling 16b CRC is by far the most obvious case if the wrong timing is used - or skipped.
+  // Technically we require 4.5ms + 14us as a worst case. We'll just call it 5ms for good measure.
+  // WARNING: Delay is based on P-variant whereby non-P *may* require different timing.
+  delay( 5 ) ;
+
+  // Adjustments as per gcopeland fork  
+  //resetcfg();
+
+  // Set 1500uS (minimum for 32B payload in ESB@250KBPS) timeouts, to make testing a little easier
+  // WARNING: If this is ever lowered, either 250KBS mode with AA is broken or maximum packet
+  // sizes must never be used. See documentation for a more complete explanation.
+  write_register(SETUP_RETR,(0b0101 << ARD) | (0b1111 << ARC));
+
+  // Restore our default PA level
+  setPALevel( RF24_PA_MAX ) ;
+
+  // Determine if this is a p or non-p RF24 module and then
+  // reset our data rate back to default value. This works
+  // because a non-P variant won't allow the data rate to
+  // be set to 250Kbps.
+  if( setDataRate( RF24_250KBPS ) )
+  {
+    p_variant = true ;
+  }
+  
+  // Then set the data rate to the slowest (and most reliable) speed supported by all
+  // hardware.
+  setDataRate( RF24_1MBPS ) ;
+
+  // Initialize CRC and request 2-byte (16bit) CRC
+  setCRCLength( RF24_CRC_16 ) ;
+  
+  // Disable dynamic payloads, to match dynamic_payloads_enabled setting
+  write_register(DYNPD,0);
+
+  // Reset current status
+  // Notice reset and flush is the last thing we do
+  write_register(STATUS,_BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
+
+  // Set up default configuration.  Callers can always change it later.
+  // This channel should be universally safe and not bleed over into adjacent
+  // spectrum.
+  setChannel(76);
+
+  // Flush buffers
+  flush_rx();
+  flush_tx();
+}
+
+/****************************************************************************/
+
+
+void RF24::resetcfg(void){
+	write_register(0x00,0x0f);
+}
+
+void RF24::startListening(void)
+{
+  write_register(CONFIG, read_register(CONFIG) | _BV(PWR_UP) | _BV(PRIM_RX));
+  write_register(STATUS, _BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
+
+  // Restore the pipe0 adddress, if exists
+  if (pipe0_reading_address)
+    write_register(RX_ADDR_P0, reinterpret_cast<const uint8_t*>(&pipe0_reading_address), 5);
+
+
+  // Adjustments as per gcopeland fork  
+  // Flush buffers
+  //flush_rx();
+  //flush_tx();
+
+  // Go!
+  ce(HIGH);
+
+  // wait for the radio to come up (130us actually only needed)
+  delayMicroseconds(130);
+}
+
+/****************************************************************************/
+
+void RF24::stopListening(void)
+{
+  ce(LOW);
+  flush_tx();
+  flush_rx();
+}
+
+/****************************************************************************/
+
+void RF24::powerDown(void)
+{
+  write_register(CONFIG,read_register(CONFIG) & ~_BV(PWR_UP));
+
+// Adjustments as per gcopeland fork  
+  delayMicroseconds(150);
+}
+
+/****************************************************************************/
+
+void RF24::powerUp(void)
+{
+  write_register(CONFIG,read_register(CONFIG) | _BV(PWR_UP));
+// Adjustments as per gcopeland fork  
+  delayMicroseconds(150);
+}
+
+/******************************************************************/
+
+bool RF24::write( const void* buf, uint8_t len )
+{
+  bool result = false;
+
+  // Begin the write
+  startWrite(buf,len);
+
+  uint8_t observe_tx;
+  uint8_t status;
+  uint32_t sent_at = millis();
+  const uint32_t timeout = 500; //ms to wait for timeout
+  do
+  {
+    status = read_register(OBSERVE_TX,&observe_tx,1);
+    IF_SERIAL_DEBUG(printf(observe_tx,HEX));
+  }
+  while( ! ( status & ( _BV(TX_DS) | _BV(MAX_RT) ) ) && ( millis() - sent_at < timeout ) );
+
+  bool tx_ok, tx_fail;
+  whatHappened(tx_ok,tx_fail,ack_payload_available);
+  
+  //printf("%u%u%u\r\n",tx_ok,tx_fail,ack_payload_available);
+
+  result = tx_ok;
+  IF_SERIAL_DEBUG(printf(result?"...OK.":"...Failed"));
+
+  // Handle the ack packet
+  if ( ack_payload_available )
+  {
+    ack_payload_length = getDynamicPayloadSize();
+    IF_SERIAL_DEBUG(printf("[AckPacket]/"));
+    IF_SERIAL_DEBUG(printfln(ack_payload_length,DEC));
+  }
+
+
+  // Disable powerDown and flush_tx as per gcopeland fork
+  //powerDown();
+  //flush_tx();
+
+  return result;
+}
+/****************************************************************************/
+
+void RF24::startWrite( const void* buf, uint8_t len )
+{
+  // Transmitter power-up
+  write_register(CONFIG, ( read_register(CONFIG) | _BV(PWR_UP) ) & ~_BV(PRIM_RX) );
+// Adjustments as per gcopeland fork  
+// delayMicroseconds(150);
+
+  // Send the payload
+  write_payload( buf, len );
+
+  // Allons!
+  ce(HIGH);
+  delayMicroseconds(10);
+  ce(LOW);
+}
+
+/****************************************************************************/
+
+uint8_t RF24::getDynamicPayloadSize(void)
+{
+  uint8_t result = 0;
+
+  csn(LOW);
+  spi->transfer( R_RX_PL_WID );
+  result = spi->transfer(0xff);
+  csn(HIGH);
+
+  return result;
+}
+
+/****************************************************************************/
+
+bool RF24::available(void)
+{
+  return available(NULL);
+}
+
+/****************************************************************************/
+
+bool RF24::available(uint8_t* pipe_num)
+{
+  uint8_t status = get_status();
+
+  // Too noisy, enable if you really want lots o data!!
+  //IF_SERIAL_DEBUG(print_status(status));
+
+  bool result = ( status & _BV(RX_DR) );
+
+  if (result)
+  {
+    // If the caller wants the pipe number, include that
+    if ( pipe_num )
+      *pipe_num = ( status >> RX_P_NO ) & 0b111;
+
+    // Clear the status bit
+
+    // ??? Should this REALLY be cleared now?  Or wait until we
+    // actually READ the payload?
+
+    write_register(STATUS,_BV(RX_DR) );
+
+    // Handle ack payload receipt
+    if ( status & _BV(TX_DS) )
+    {
+      write_register(STATUS,_BV(TX_DS));
+    }
+  }
+
+  return result;
+}
+
+/****************************************************************************/
+
+bool RF24::read( void* buf, uint8_t len )
+{
+  // Fetch the payload
+  read_payload( buf, len );
+
+  // was this the last of the data available?
+  return read_register(FIFO_STATUS) & _BV(RX_EMPTY);
+}
+
+/****************************************************************************/
+
+void RF24::whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready)
+{
+  // Read the status & reset the status in one easy call
+  // Or is that such a good idea?
+  uint8_t status = write_register(STATUS,_BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
+
+  // Report to the user what happened
+  tx_ok = status & _BV(TX_DS);
+  tx_fail = status & _BV(MAX_RT);
+  rx_ready = status & _BV(RX_DR);
+}
+
+/****************************************************************************/
+
+void RF24::openWritingPipe(uint64_t value)
+{
+  // Note that AVR 8-bit uC's store this LSB first, and the NRF24L01(+)
+  // expects it LSB first too, so we're good.
+
+  write_register(RX_ADDR_P0, reinterpret_cast<uint8_t*>(&value), 5);
+  write_register(TX_ADDR, reinterpret_cast<uint8_t*>(&value), 5);
+
+  const uint8_t max_payload_size = 32;
+  write_register(RX_PW_P0,min(payload_size,max_payload_size));
+}
+
+/****************************************************************************/
+
+static const uint8_t child_pipe[] PROGMEM =
+{
+  RX_ADDR_P0, RX_ADDR_P1, RX_ADDR_P2, RX_ADDR_P3, RX_ADDR_P4, RX_ADDR_P5
+};
+static const uint8_t child_payload_size[] PROGMEM =
+{
+  RX_PW_P0, RX_PW_P1, RX_PW_P2, RX_PW_P3, RX_PW_P4, RX_PW_P5
+};
+static const uint8_t child_pipe_enable[] PROGMEM =
+{
+  ERX_P0, ERX_P1, ERX_P2, ERX_P3, ERX_P4, ERX_P5
+};
+
+void RF24::openReadingPipe(uint8_t child, uint64_t address)
+{
+  // If this is pipe 0, cache the address.  This is needed because
+  // openWritingPipe() will overwrite the pipe 0 address, so
+  // startListening() will have to restore it.
+  if (child == 0)
+    pipe0_reading_address = address;
+
+  if (child <= 6)
+  {
+    // For pipes 2-5, only write the LSB
+    if ( child < 2 )
+      write_register(pgm_read_byte(&child_pipe[child]), reinterpret_cast<const uint8_t*>(&address), 5);
+    else
+      write_register(pgm_read_byte(&child_pipe[child]), reinterpret_cast<const uint8_t*>(&address), 1);
+
+    write_register(pgm_read_byte(&child_payload_size[child]),payload_size);
+
+    // Note it would be more efficient to set all of the bits for all open
+    // pipes at once.  However, I thought it would make the calling code
+    // more simple to do it this way.
+    write_register(EN_RXADDR,read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[child])));
+  }
+}
+
+/****************************************************************************/
+
+void RF24::toggle_features(void)
+{
+  csn(LOW);
+  spi->transfer( ACTIVATE );
+  spi->transfer( 0x73 );
+  csn(HIGH);
+}
+
+/****************************************************************************/
+
+void RF24::enableDynamicPayloads(void)
+{
+  // Enable dynamic payload throughout the system
+  write_register(FEATURE,read_register(FEATURE) | _BV(EN_DPL) );
+
+  // If it didn't work, the features are not enabled
+  if ( ! read_register(FEATURE) )
+  {
+    // So enable them and try again
+    toggle_features();
+    write_register(FEATURE,read_register(FEATURE) | _BV(EN_DPL) );
+  }
+
+  IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n",read_register(FEATURE)));
+
+  // Enable dynamic payload on all pipes
+  //
+  // Not sure the use case of only having dynamic payload on certain
+  // pipes, so the library does not support it.
+  write_register(DYNPD,read_register(DYNPD) | _BV(DPL_P5) | _BV(DPL_P4) | _BV(DPL_P3) | _BV(DPL_P2) | _BV(DPL_P1) | _BV(DPL_P0));
+
+  dynamic_payloads_enabled = true;
+}
+
+/****************************************************************************/
+
+void RF24::enableAckPayload(void)
+{
+  //
+  // enable ack payload and dynamic payload features
+  //
+
+  write_register(FEATURE,read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
+
+  // If it didn't work, the features are not enabled
+  if ( ! read_register(FEATURE) )
+  {
+    // So enable them and try again
+    toggle_features();
+    write_register(FEATURE,read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
+  }
+
+  IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n",read_register(FEATURE)));
+
+  //
+  // Enable dynamic payload on pipes 0 & 1
+  //
+
+  write_register(DYNPD,read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
+}
+
+/****************************************************************************/
+
+void RF24::writeAckPayload(uint8_t pipe, const void* buf, uint8_t len)
+{
+  const uint8_t* current = reinterpret_cast<const uint8_t*>(buf);
+
+  csn(LOW);
+  spi->transfer( W_ACK_PAYLOAD | ( pipe & 0b111 ) );
+  const uint8_t max_payload_size = 32;
+  uint8_t data_len = min(len,max_payload_size);
+  while ( data_len-- )
+    spi->transfer(*current++);
+
+  csn(HIGH);
+}
+
+/****************************************************************************/
+
+bool RF24::isAckPayloadAvailable(void)
+{
+  bool result = ack_payload_available;
+  ack_payload_available = false;
+  return result;
+}
+
+/****************************************************************************/
+
+bool RF24::isPVariant(void)
+{
+  return p_variant ;
+}
+
+/****************************************************************************/
+
+void RF24::setAutoAck(bool enable)
+{
+  if ( enable )
+    write_register(EN_AA, 0b111111);
+  else
+    write_register(EN_AA, 0);
+}
+
+/****************************************************************************/
+
+void RF24::setAutoAck( uint8_t pipe, bool enable )
+{
+  if ( pipe <= 6 )
+  {
+    uint8_t en_aa = read_register( EN_AA ) ;
+    if( enable )
+    {
+      en_aa |= _BV(pipe) ;
+    }
+    else
+    {
+      en_aa &= ~_BV(pipe) ;
+    }
+    write_register( EN_AA, en_aa ) ;
+  }
+}
+
+/****************************************************************************/
+
+bool RF24::testCarrier(void)
+{
+  return ( read_register(CD) & 1 );
+}
+
+/****************************************************************************/
+
+bool RF24::testRPD(void)
+{
+  return ( read_register(RPD) & 1 ) ;
+}
+
+/****************************************************************************/
+
+void RF24::setPALevel(rf24_pa_dbm_e level)
+{
+  uint8_t setup = read_register(RF_SETUP) ;
+  setup &= ~(_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
+
+  // switch uses RAM (evil!)
+  if ( level == RF24_PA_MAX )
+  {
+    setup |= (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
+  }
+  else if ( level == RF24_PA_HIGH )
+  {
+    setup |= _BV(RF_PWR_HIGH) ;
+  }
+  else if ( level == RF24_PA_LOW )
+  {
+    setup |= _BV(RF_PWR_LOW);
+  }
+  else if ( level == RF24_PA_MIN )
+  {
+    // nothing
+  }
+  else if ( level == RF24_PA_ERROR )
+  {
+    // On error, go to maximum PA
+    setup |= (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
+  }
+
+  write_register( RF_SETUP, setup ) ;
+}
+
+/****************************************************************************/
+
+rf24_pa_dbm_e RF24::getPALevel(void)
+{
+  rf24_pa_dbm_e result = RF24_PA_ERROR ;
+  uint8_t power = read_register(RF_SETUP) & (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
+
+  // switch uses RAM (evil!)
+  if ( power == (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) )
+  {
+    result = RF24_PA_MAX ;
+  }
+  else if ( power == _BV(RF_PWR_HIGH) )
+  {
+    result = RF24_PA_HIGH ;
+  }
+  else if ( power == _BV(RF_PWR_LOW) )
+  {
+    result = RF24_PA_LOW ;
+  }
+  else
+  {
+    result = RF24_PA_MIN ;
+  }
+
+  return result ;
+}
+
+/****************************************************************************/
+
+bool RF24::setDataRate(rf24_datarate_e speed)
+{
+  bool result = false;
+  uint8_t setup = read_register(RF_SETUP) ;
+
+  // HIGH and LOW '00' is 1Mbs - our default
+  wide_band = false ;
+  setup &= ~(_BV(RF_DR_LOW) | _BV(RF_DR_HIGH)) ;
+  if( speed == RF24_250KBPS )
+  {
+    // Must set the RF_DR_LOW to 1; RF_DR_HIGH (used to be RF_DR) is already 0
+    // Making it '10'.
+    wide_band = false ;
+    setup |= _BV( RF_DR_LOW ) ;
+  }
+  else
+  {
+    // Set 2Mbs, RF_DR (RF_DR_HIGH) is set 1
+    // Making it '01'
+    if ( speed == RF24_2MBPS )
+    {
+      wide_band = true ;
+      setup |= _BV(RF_DR_HIGH);
+    }
+    else
+    {
+      // 1Mbs
+      wide_band = false ;
+    }
+  }
+  write_register(RF_SETUP,setup);
+
+  // Verify our result
+  if ( read_register(RF_SETUP) == setup )
+  {
+    result = true;
+  }
+  else
+  {
+    wide_band = false;
+  }
+
+  return result;
+}
+
+/****************************************************************************/
+
+rf24_datarate_e RF24::getDataRate( void )
+{
+  rf24_datarate_e result ;
+  uint8_t dr = read_register(RF_SETUP) & (_BV(RF_DR_LOW) | _BV(RF_DR_HIGH));
+  
+  // switch uses RAM (evil!)
+  // Order matters in our case below
+  if ( dr == _BV(RF_DR_LOW) )
+  {
+    // '10' = 250KBPS
+    result = RF24_250KBPS ;
+  }
+  else if ( dr == _BV(RF_DR_HIGH) )
+  {
+    // '01' = 2MBPS
+    result = RF24_2MBPS ;
+  }
+  else
+  {
+    // '00' = 1MBPS
+    result = RF24_1MBPS ;
+  }
+  return result ;
+}
+
+/****************************************************************************/
+
+void RF24::setCRCLength(rf24_crclength_e length)
+{
+  uint8_t config = read_register(CONFIG) & ~( _BV(CRCO) | _BV(EN_CRC)) ;
+  
+  // switch uses RAM (evil!)
+  if ( length == RF24_CRC_DISABLED )
+  {
+    // Do nothing, we turned it off above. 
+  }
+  else if ( length == RF24_CRC_8 )
+  {
+    config |= _BV(EN_CRC);
+  }
+  else
+  {
+    config |= _BV(EN_CRC);
+    config |= _BV( CRCO );
+  }
+  write_register( CONFIG, config ) ;
+}
+
+/****************************************************************************/
+
+rf24_crclength_e RF24::getCRCLength(void)
+{
+  rf24_crclength_e result = RF24_CRC_DISABLED;
+  uint8_t config = read_register(CONFIG) & ( _BV(CRCO) | _BV(EN_CRC)) ;
+
+  if ( config & _BV(EN_CRC ) )
+  {
+    if ( config & _BV(CRCO) )
+      result = RF24_CRC_16;
+    else
+      result = RF24_CRC_8;
+  }
+
+  return result;
+}
+
+/****************************************************************************/
+
+void RF24::disableCRC( void )
+{
+  uint8_t disable = read_register(CONFIG) & ~_BV(EN_CRC) ;
+  write_register( CONFIG, disable ) ;
+}
+
+/****************************************************************************/
+void RF24::setRetries(uint8_t delay, uint8_t count)
+{
+ write_register(SETUP_RETR,(delay&0xf)<<ARD | (count&0xf)<<ARC);
+}
+
+// vim:ai:cin:sts=2 sw=2 ft=cpp
+

--- a/librf24-rpi/librf24-WiringPi/RF24.h
+++ b/librf24-rpi/librf24-WiringPi/RF24.h
@@ -1,0 +1,823 @@
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ */
+
+/**
+ * @file RF24.h
+ *
+ * Class declaration for RF24 and helper enums
+ */
+
+#ifndef __RF24_H__
+#define __RF24_H__
+
+#include "RF24_config.h"
+#include <wiringPi.h>
+
+/**
+ * Power Amplifier level.
+ *
+ * For use with setPALevel()
+ */
+typedef enum { RF24_PA_MIN = 0,RF24_PA_LOW, RF24_PA_HIGH, RF24_PA_MAX, RF24_PA_ERROR } rf24_pa_dbm_e ;
+
+/**
+ * Data rate.  How fast data moves through the air.
+ *
+ * For use with setDataRate()
+ */
+typedef enum { RF24_1MBPS = 0, RF24_2MBPS, RF24_250KBPS } rf24_datarate_e;
+
+/**
+ * CRC Length.  How big (if any) of a CRC is included.
+ *
+ * For use with setCRCLength()
+ */
+typedef enum { RF24_CRC_DISABLED = 0, RF24_CRC_8, RF24_CRC_16 } rf24_crclength_e;
+
+/**
+ * Driver for nRF24L01(+) 2.4GHz Wireless Transceiver
+ */
+
+class RF24
+{
+private:
+  uint8_t ce_pin; /**< "Chip Enable" pin, activates the RX or TX role, unused on rpi */
+  string spidevice;
+  uint32_t spispeed;
+  uint8_t csn_pin; /**< SPI Chip select */
+  bool wide_band; /* 2Mbs data rate in use? */
+  bool p_variant; /* False for RF24L01 and true for RF24L01P */
+  uint8_t payload_size; /**< Fixed size of payloads */
+  bool ack_payload_available; /**< Whether there is an ack payload waiting */
+  bool dynamic_payloads_enabled; /**< Whether dynamic payloads are enabled. */ 
+  uint8_t ack_payload_length; /**< Dynamic size of pending ack payload. */
+  uint64_t pipe0_reading_address; /**< Last address set on pipe 0 for reading. */
+
+  SPI* spi;
+  
+protected:
+  /**
+   * @name Low-level internal interface.
+   *
+   *  Protected methods that address the chip directly.  Regular users cannot
+   *  ever call these.  They are documented for completeness and for developers who
+   *  may want to extend this class.
+   */
+  /**@{*/
+
+  /**
+   * Set chip select pin
+   *
+   * Running SPI bus at PI_CLOCK_DIV2 so we don't waste time transferring data
+   * and best of all, we make use of the radio's FIFO buffers. A lower speed
+   * means we're less likely to effectively leverage our FIFOs and pay a higher
+   * AVR runtime cost as toll.
+   *
+   * @param mode HIGH to take this unit off the SPI bus, LOW to put it on
+   */
+  void csn(int mode);
+
+  /**
+   * Set chip enable
+   *
+   * @param level HIGH to actively begin transmission or LOW to put in standby.  Please see data sheet
+   * for a much more detailed description of this pin.
+   */
+  void ce(int level);
+
+  /**
+   * Read a chunk of data in from a register
+   *
+   * @param reg Which register. Use constants from nRF24L01.h
+   * @param buf Where to put the data
+   * @param len How many bytes of data to transfer
+   * @return Current value of status register
+   */
+  uint8_t read_register(uint8_t reg, uint8_t* buf, uint8_t len);
+
+  /**
+   * Read single byte from a register
+   *
+   * @param reg Which register. Use constants from nRF24L01.h
+   * @return Current value of register @p reg
+   */
+  uint8_t read_register(uint8_t reg);
+
+  /**
+   * Write a chunk of data to a register
+   *
+   * @param reg Which register. Use constants from nRF24L01.h
+   * @param buf Where to get the data
+   * @param len How many bytes of data to transfer
+   * @return Current value of status register
+   */
+  uint8_t write_register(uint8_t reg, const uint8_t* buf, uint8_t len);
+
+  /**
+   * Write a single byte to a register
+   *
+   * @param reg Which register. Use constants from nRF24L01.h
+   * @param value The new value to write
+   * @return Current value of status register
+   */
+  uint8_t write_register(uint8_t reg, uint8_t value);
+
+  /**
+   * Write the transmit payload
+   *
+   * The size of data written is the fixed payload size, see getPayloadSize()
+   *
+   * @param buf Where to get the data
+   * @param len Number of bytes to be sent
+   * @return Current value of status register
+   */
+  uint8_t write_payload(const void* buf, uint8_t len);
+
+  /**
+   * Read the receive payload
+   *
+   * The size of data read is the fixed payload size, see getPayloadSize()
+   *
+   * @param buf Where to put the data
+   * @param len Maximum number of bytes to read
+   * @return Current value of status register
+   */
+  uint8_t read_payload(void* buf, uint8_t len);
+
+  /**
+   * Empty the receive buffer
+   *
+   * @return Current value of status register
+   */
+  uint8_t flush_rx(void);
+
+  /**
+   * Empty the transmit buffer
+   *
+   * @return Current value of status register
+   */
+  uint8_t flush_tx(void);
+
+  /**
+   * Retrieve the current status of the chip
+   *
+   * @return Current value of status register
+   */
+  uint8_t get_status(void);
+
+  /**
+   * Decode and print the given status to stdout
+   *
+   * @param status Status value to print
+   *
+   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
+   */
+  void print_status(uint8_t status);
+
+  /**
+   * Decode and print the given 'observe_tx' value to stdout
+   *
+   * @param value The observe_tx value to print
+   *
+   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
+   */
+  void print_observe_tx(uint8_t value);
+
+  /**
+   * Print the name and value of an 8-bit register to stdout
+   *
+   * Optionally it can print some quantity of successive
+   * registers on the same line.  This is useful for printing a group
+   * of related registers on one line.
+   *
+   * @param name Name of the register
+   * @param reg Which register. Use constants from nRF24L01.h
+   * @param qty How many successive registers to print
+   */
+  void print_byte_register(const char* name, uint8_t reg, uint8_t qty = 1);
+
+  /**
+   * Print the name and value of a 40-bit address register to stdout
+   *
+   * Optionally it can print some quantity of successive
+   * registers on the same line.  This is useful for printing a group
+   * of related registers on one line.
+   *
+   * @param name Name of the register
+   * @param reg Which register. Use constants from nRF24L01.h
+   * @param qty How many successive registers to print
+   */
+  void print_address_register(const char* name, uint8_t reg, uint8_t qty = 1);
+
+  /**
+   * Turn on or off the special features of the chip
+   *
+   * The chip has certain 'features' which are only available when the 'features'
+   * are enabled.  See the datasheet for details.
+   */
+  void toggle_features(void);
+  /**@}*/
+
+public:
+  /**
+   * @name Primary public interface
+   *
+   *  These are the main methods you need to operate the chip
+   */
+  /**@{*/
+
+  /**
+   * Constructor
+   *
+   * Creates a new instance of this driver.  Before using, you create an instance
+   * and send in the unique pins that this chip is connected to.
+   *
+   * @param _cepin The pin attached to Chip Enable on the RF module
+   * @param _cspin The pin attached to Chip SPI chipSelect
+   */
+  RF24(uint8_t _cepin, uint8_t _cspin);
+  RF24(string _spidevice, uint32_t _spispeed, uint8_t _cepin);
+
+  /**
+   * Begin operation of the chip
+   *
+   * Call this in setup(), before calling any other methods.
+   */
+  void begin(int wiringPiMode);
+
+ /**
+   * Reset confguration of the chip
+   *
+   * Call this to reset all registers
+   */
+  void resetcfg(void);
+
+  /**
+   * Start listening on the pipes opened for reading.
+   *
+   * Be sure to call openReadingPipe() first.  Do not call write() while
+   * in this mode, without first calling stopListening().  Call
+   * isAvailable() to check for incoming traffic, and read() to get it.
+   */
+  void startListening(void);
+
+  /**
+   * Stop listening for incoming messages
+   *
+   * Do this before calling write().
+   */
+  void stopListening(void);
+
+  /**
+   * Write to the open writing pipe
+   *
+   * Be sure to call openWritingPipe() first to set the destination
+   * of where to write to.
+   *
+   * This blocks until the message is successfully acknowledged by
+   * the receiver or the timeout/retransmit maxima are reached.  In
+   * the current configuration, the max delay here is 60ms.
+   *
+   * The maximum size of data written is the fixed payload size, see
+   * getPayloadSize().  However, you can write less, and the remainder
+   * will just be filled with zeroes.
+   *
+   * @param buf Pointer to the data to be sent
+   * @param len Number of bytes to be sent
+   * @return True if the payload was delivered successfully false if not
+   */
+  bool write( const void* buf, uint8_t len );
+
+  /**
+   * Test whether there are bytes available to be read
+   *
+   * @return True if there is a payload available, false if none is
+   */
+  bool available(void);
+
+  /**
+   * Read the payload
+   *
+   * Return the last payload received
+   *
+   * The size of data read is the fixed payload size, see getPayloadSize()
+   *
+   * @note I specifically chose 'void*' as a data type to make it easier
+   * for beginners to use.  No casting needed.
+   *
+   * @param buf Pointer to a buffer where the data should be written
+   * @param len Maximum number of bytes to read into the buffer
+   * @return True if the payload was delivered successfully false if not
+   */
+  bool read( void* buf, uint8_t len );
+
+  /**
+   * Open a pipe for writing
+   *
+   * Only one pipe can be open at once, but you can change the pipe
+   * you'll listen to.  Do not call this while actively listening.
+   * Remember to stopListening() first.
+   *
+   * Addresses are 40-bit hex values, e.g.:
+   *
+   * @code
+   *   openWritingPipe(0xF0F0F0F0F0);
+   * @endcode
+   *
+   * @param address The 40-bit address of the pipe to open.  This can be
+   * any value whatsoever, as long as you are the only one writing to it
+   * and only one other radio is listening to it.  Coordinate these pipe
+   * addresses amongst nodes on the network.
+   */
+  void openWritingPipe(uint64_t address);
+
+  /**
+   * Open a pipe for reading
+   *
+   * Up to 6 pipes can be open for reading at once.  Open all the
+   * reading pipes, and then call startListening().
+   *
+   * @see openWritingPipe
+   *
+   * @warning Pipes 1-5 should share the first 32 bits.
+   * Only the least significant byte should be unique, e.g.
+   * @code
+   *   openReadingPipe(1,0xF0F0F0F0AA);
+   *   openReadingPipe(2,0xF0F0F0F066);
+   * @endcode
+   *
+   * @warning Pipe 0 is also used by the writing pipe.  So if you open
+   * pipe 0 for reading, and then startListening(), it will overwrite the
+   * writing pipe.  Ergo, do an openWritingPipe() again before write().
+   *
+   * @todo Enforce the restriction that pipes 1-5 must share the top 32 bits
+   *
+   * @param number Which pipe# to open, 0-5.
+   * @param address The 40-bit address of the pipe to open.
+   */
+  void openReadingPipe(uint8_t number, uint64_t address);
+
+  /**@}*/
+  /**
+   * @name Optional Configurators 
+   *
+   *  Methods you can use to get or set the configuration of the chip.
+   *  None are required.  Calling begin() sets up a reasonable set of
+   *  defaults.
+   */
+  /**@{*/
+  /**
+   * Set the number and delay of retries upon failed submit
+   *
+   * @param delay How long to wait between each retry, in multiples of 250us,
+   * max is 15.  0 means 250us, 15 means 4000us.
+   * @param count How many retries before giving up, max 15
+   */
+  void setRetries(uint8_t delay, uint8_t count);
+
+  /**
+   * Set RF communication channel
+   *
+   * @param channel Which RF channel to communicate on, 0-127
+   */
+  void setChannel(uint8_t channel);
+
+  /**
+   * Set Static Payload Size
+   *
+   * This implementation uses a pre-stablished fixed payload size for all
+   * transmissions.  If this method is never called, the driver will always
+   * transmit the maximum payload size (32 bytes), no matter how much
+   * was sent to write().
+   *
+   * @todo Implement variable-sized payloads feature
+   *
+   * @param size The number of bytes in the payload
+   */
+  void setPayloadSize(uint8_t size);
+
+  /**
+   * Get Static Payload Size
+   *
+   * @see setPayloadSize()
+   *
+   * @return The number of bytes in the payload
+   */
+  uint8_t getPayloadSize(void);
+
+  /**
+   * Get Dynamic Payload Size
+   *
+   * For dynamic payloads, this pulls the size of the payload off
+   * the chip
+   *
+   * @return Payload length of last-received dynamic payload
+   */
+  uint8_t getDynamicPayloadSize(void);
+  
+  /**
+   * Enable custom payloads on the acknowledge packets
+   *
+   * Ack payloads are a handy way to return data back to senders without
+   * manually changing the radio modes on both units.
+   *
+   * @see examples/pingpair_pl/pingpair_pl.pde
+   */
+  void enableAckPayload(void);
+
+  /**
+   * Enable dynamically-sized payloads
+   *
+   * This way you don't always have to send large packets just to send them
+   * once in a while.  This enables dynamic payloads on ALL pipes.
+   *
+   * @see examples/pingpair_pl/pingpair_dyn.pde
+   */
+  void enableDynamicPayloads(void);
+
+  /**
+   * Determine whether the hardware is an nRF24L01+ or not.
+   *
+   * @return true if the hardware is nRF24L01+ (or compatible) and false
+   * if its not.
+   */
+  bool isPVariant(void) ;
+
+  /**
+   * Enable or disable auto-acknowlede packets
+   *
+   * This is enabled by default, so it's only needed if you want to turn
+   * it off for some reason.
+   *
+   * @param enable Whether to enable (true) or disable (false) auto-acks
+   */
+  void setAutoAck(bool enable);
+
+  /**
+   * Enable or disable auto-acknowlede packets on a per pipeline basis.
+   *
+   * AA is enabled by default, so it's only needed if you want to turn
+   * it off/on for some reason on a per pipeline basis.
+   *
+   * @param pipe Which pipeline to modify
+   * @param enable Whether to enable (true) or disable (false) auto-acks
+   */
+  void setAutoAck( uint8_t pipe, bool enable ) ;
+
+  /**
+   * Set Power Amplifier (PA) level to one of four levels.
+   * Relative mnemonics have been used to allow for future PA level
+   * changes. According to 6.5 of the nRF24L01+ specification sheet,
+   * they translate to: RF24_PA_MIN=-18dBm, RF24_PA_LOW=-12dBm,
+   * RF24_PA_MED=-6dBM, and RF24_PA_HIGH=0dBm.
+   *
+   * @param level Desired PA level.
+   */
+  void setPALevel( rf24_pa_dbm_e level ) ;
+
+  /**
+   * Fetches the current PA level.
+   *
+   * @return Returns a value from the rf24_pa_dbm_e enum describing
+   * the current PA setting. Please remember, all values represented
+   * by the enum mnemonics are negative dBm. See setPALevel for
+   * return value descriptions.
+   */
+  rf24_pa_dbm_e getPALevel( void ) ;
+
+  /**
+   * Set the transmission data rate
+   *
+   * @warning setting RF24_250KBPS will fail for non-plus units
+   *
+   * @param speed RF24_250KBPS for 250kbs, RF24_1MBPS for 1Mbps, or RF24_2MBPS for 2Mbps
+   * @return true if the change was successful
+   */
+  bool setDataRate(rf24_datarate_e speed);
+  
+  /**
+   * Fetches the transmission data rate
+   *
+   * @return Returns the hardware's currently configured datarate. The value
+   * is one of 250kbs, RF24_1MBPS for 1Mbps, or RF24_2MBPS, as defined in the
+   * rf24_datarate_e enum.
+   */
+  rf24_datarate_e getDataRate( void ) ;
+
+  /**
+   * Set the CRC length
+   *
+   * @param length RF24_CRC_8 for 8-bit or RF24_CRC_16 for 16-bit
+   */
+  void setCRCLength(rf24_crclength_e length);
+
+  /**
+   * Get the CRC length
+   *
+   * @return RF24_DISABLED if disabled or RF24_CRC_8 for 8-bit or RF24_CRC_16 for 16-bit
+   */
+  rf24_crclength_e getCRCLength(void);
+
+  /**
+   * Disable CRC validation
+   *
+   */
+  void disableCRC( void ) ;
+
+  /**@}*/
+  /**
+   * @name Advanced Operation 
+   *
+   *  Methods you can use to drive the chip in more advanced ways 
+   */
+  /**@{*/
+
+  /**
+   * Print a giant block of debugging information to stdout
+   *
+   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
+   */
+  void printDetails(void);
+
+  /**
+   * Enter low-power mode
+   *
+   * To return to normal power mode, either write() some data or
+   * startListening, or powerUp().
+   */
+  void powerDown(void);
+
+  /**
+   * Leave low-power mode - making radio more responsive
+   *
+   * To return to low power mode, call powerDown().
+   */
+  void powerUp(void) ;
+
+  /**
+   * Test whether there are bytes available to be read
+   *
+   * Use this version to discover on which pipe the message
+   * arrived.
+   *
+   * @param[out] pipe_num Which pipe has the payload available
+   * @return True if there is a payload available, false if none is
+   */
+  bool available(uint8_t* pipe_num);
+
+  /**
+   * Non-blocking write to the open writing pipe
+   *
+   * Just like write(), but it returns immediately. To find out what happened
+   * to the send, catch the IRQ and then call whatHappened().
+   *
+   * @see write()
+   * @see whatHappened()
+   *
+   * @param buf Pointer to the data to be sent
+   * @param len Number of bytes to be sent
+   * @return True if the payload was delivered successfully false if not
+   */
+  void startWrite( const void* buf, uint8_t len );
+
+  /**
+   * Write an ack payload for the specified pipe
+   *
+   * The next time a message is received on @p pipe, the data in @p buf will
+   * be sent back in the acknowledgement.
+   *
+   * @warning According to the data sheet, only three of these can be pending
+   * at any time.  I have not tested this.
+   *
+   * @param pipe Which pipe# (typically 1-5) will get this response.
+   * @param buf Pointer to data that is sent
+   * @param len Length of the data to send, up to 32 bytes max.  Not affected
+   * by the static payload set by setPayloadSize().
+   */
+  void writeAckPayload(uint8_t pipe, const void* buf, uint8_t len);
+
+  /**
+   * Determine if an ack payload was received in the most recent call to
+   * write().
+   *
+   * Call read() to retrieve the ack payload.
+   *
+   * @warning Calling this function clears the internal flag which indicates
+   * a payload is available.  If it returns true, you must read the packet
+   * out as the very next interaction with the radio, or the results are
+   * undefined.
+   *
+   * @return True if an ack payload is available.
+   */
+  bool isAckPayloadAvailable(void);
+
+  /**
+   * Call this when you get an interrupt to find out why
+   *
+   * Tells you what caused the interrupt, and clears the state of
+   * interrupts.
+   *
+   * @param[out] tx_ok The send was successful (TX_DS)
+   * @param[out] tx_fail The send failed, too many retries (MAX_RT)
+   * @param[out] rx_ready There is a message waiting to be read (RX_DS)
+   */
+  void whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready);
+
+  /**
+   * Test whether there was a carrier on the line for the
+   * previous listening period.
+   *
+   * Useful to check for interference on the current channel.
+   *
+   * @return true if was carrier, false if not
+   */
+  bool testCarrier(void);
+
+  /**
+   * Test whether a signal (carrier or otherwise) greater than
+   * or equal to -64dBm is present on the channel. Valid only
+   * on nRF24L01P (+) hardware. On nRF24L01, use testCarrier().
+   *
+   * Useful to check for interference on the current channel and
+   * channel hopping strategies.
+   *
+   * @return true if signal => -64dBm, false if not
+   */
+  bool testRPD(void) ;
+
+  /**@}*/
+};
+
+/**
+ * @example GettingStarted.pde
+ *
+ * This is an example which corresponds to my "Getting Started" blog post:
+ * <a style="text-align:center" href="http://maniacbug.wordpress.com/2011/11/02/getting-started-rf24/">Getting Started with nRF24L01+ on Arduino</a>. 
+ *
+ * It is an example of how to use the RF24 class.  Write this sketch to two 
+ * different nodes.  Put one of the nodes into 'transmit' mode by connecting 
+ * with the serial monitor and sending a 'T'.  The ping node sends the current 
+ * time to the pong node, which responds by sending the value back.  The ping 
+ * node can then see how long the whole cycle took.
+ */
+
+/**
+ * @example nordic_fob.pde
+ *
+ * This is an example of how to use the RF24 class to receive signals from the
+ * Sparkfun Nordic FOB.  See http://www.sparkfun.com/products/8602 .
+ * Thanks to Kirk Mower for providing test hardware.
+ */
+
+/**
+ * @example led_remote.pde
+ *
+ * This is an example of how to use the RF24 class to control a remote
+ * bank of LED's using buttons on a remote control.
+ *
+ * Every time the buttons change on the remote, the entire state of
+ * buttons is send to the led board, which displays the state.
+ */
+
+/**
+ * @example pingpair.pde
+ *
+ * This is an example of how to use the RF24 class.  Write this sketch to two
+ * different nodes, connect the role_pin to ground on one.  The ping node sends
+ * the current time to the pong node, which responds by sending the value back.
+ * The ping node can then see how long the whole cycle took.
+ */
+
+/**
+ * @example pingpair_maple.pde 
+ *
+ * This is an example of how to use the RF24 class on the Maple.  For a more
+ * detailed explanation, see my blog post:
+ * <a href="http://maniacbug.wordpress.com/2011/12/14/nrf24l01-running-on-maple-3/">nRF24L01+ Running on Maple</a>
+ *
+ * It will communicate well to an Arduino-based unit as well, so it's not for only Maple-to-Maple communication.
+ * 
+ * Write this sketch to two different nodes,
+ * connect the role_pin to ground on one.  The ping node sends the current time to the pong node,
+ * which responds by sending the value back.  The ping node can then see how long the whole cycle
+ * took.
+ */
+
+/**
+ * @example starping.pde
+ *
+ * This sketch is a more complex example of using the RF24 library for Arduino.
+ * Deploy this on up to six nodes.  Set one as the 'pong receiver' by tying the
+ * role_pin low, and the others will be 'ping transmit' units.  The ping units
+ * unit will send out the value of millis() once a second.  The pong unit will
+ * respond back with a copy of the value.  Each ping unit can get that response
+ * back, and determine how long the whole cycle took.
+ *
+ * This example requires a bit more complexity to determine which unit is which.
+ * The pong receiver is identified by having its role_pin tied to ground.
+ * The ping senders are further differentiated by a byte in eeprom.
+ */
+
+/**
+ * @example pingpair_pl.pde
+ *
+ * This is an example of how to do two-way communication without changing
+ * transmit/receive modes.  Here, a payload is set to the transmitter within
+ * the Ack packet of each transmission.  Note that the payload is set BEFORE
+ * the sender's message arrives.
+ */
+
+/**
+ * @example pingpair_irq.pde
+ *
+ * This is an example of how to user interrupts to interact with the radio.
+ * It builds on the pingpair_pl example, and uses ack payloads.
+ */
+
+/**
+ * @example pingpair_sleepy.pde
+ *
+ * This is an example of how to use the RF24 class to create a battery-
+ * efficient system.  It is just like the pingpair.pde example, but the
+ * ping node powers down the radio and sleeps the MCU after every
+ * ping/pong cycle.
+ */
+
+/**
+ * @example scanner.pde
+ *
+ * Example to detect interference on the various channels available.
+ * This is a good diagnostic tool to check whether you're picking a
+ * good channel for your application.
+ *
+ * Inspired by cpixip.
+ * See http://arduino.cc/forum/index.php/topic,54795.0.html
+ */
+
+/**
+ * @mainpage Driver for nRF24L01(+) 2.4GHz Wireless Transceiver
+ *
+ * @section Goals Design Goals
+ * 
+ * This library is designed to be...
+ * @li Maximally compliant with the intended operation of the chip
+ * @li Easy for beginners to use
+ * @li Consumed with a public interface that's similiar to other Arduino standard libraries
+ *
+ * @section News News
+ * 
+ * NOW COMPATIBLE WITH ARDUINO 1.0 - The 'master' branch and all examples work with both Arduino 1.0 and earlier versions.  
+ * Please <a href="https://github.com/maniacbug/RF24/issues/new">open an issue</a> if you find any problems using it with any version of Arduino.
+ *
+ * NOW COMPATIBLE WITH MAPLE - RF24 has been tested with the 
+ * <a href="http://leaflabs.com/store/#Maple-Native">Maple Native</a>, 
+ * and should work with any Maple board.  See the pingpair_maple example.
+ * Note that only the pingpair_maple example has been tested on Maple, although
+ * the others can certainly be adapted.
+ *
+ * @section Useful Useful References
+ * 
+ * Please refer to:
+ *
+ * @li <a href="http://maniacbug.github.com/RF24/">Documentation Main Page</a>
+ * @li <a href="http://maniacbug.github.com/RF24/classRF24.html">RF24 Class Documentation</a>
+ * @li <a href="https://github.com/maniacbug/RF24/">Source Code</a>
+ * @li <a href="https://github.com/maniacbug/RF24/archives/master">Downloads Page</a>
+ * @li <a href="http://www.nordicsemi.com/files/Product/data_sheet/nRF24L01_Product_Specification_v2_0.pdf">Chip Datasheet</a>
+ *
+ * This chip uses the SPI bus, plus two chip control pins.  Remember that pin 10 must still remain an output, or
+ * the SPI hardware will go into 'slave' mode.
+ *
+ * @section More More Information
+ *
+ * @subpage FAQ
+ *
+ * @section Projects Projects
+ *
+ * Stuff I have built with RF24
+ *
+ * <img src="http://farm7.staticflickr.com/6044/6307669179_a8d19298a6_m.jpg" width="240" height="160" alt="RF24 Getting Started - Finished Product">
+ *
+ * <a style="text-align:center" href="http://maniacbug.wordpress.com/2011/11/02/getting-started-rf24/">Getting Started with nRF24L01+ on Arduino</a> 
+ *
+ * <img src="http://farm8.staticflickr.com/7159/6645514331_38eb2bdeaa_m.jpg" width="240" height="160" alt="Nordic FOB and nRF24L01+">
+ *
+ * <a style="text-align:center" href="http://maniacbug.wordpress.com/2012/01/08/nordic-fob/">Using the Sparkfun Nordic FOB</a> 
+ *
+ * <img src="http://farm7.staticflickr.com/6097/6224308836_b9b3b421a3_m.jpg" width="240" height="160" alt="RF Duinode V3 (2V4)">
+ *
+ * <a href="http://maniacbug.wordpress.com/2011/10/19/sensor-node/">Low-Power Wireless Sensor Node</a>
+ *
+ * <img src="http://farm8.staticflickr.com/7012/6489477865_b56edb629b_m.jpg" width="240" height="161" alt="nRF24L01+ connected to Leaf Labs Maple Native">
+ *
+ * <a href="http://maniacbug.wordpress.com/2011/12/14/nrf24l01-running-on-maple-3/">nRF24L01+ Running on Maple</a>
+ */
+
+#endif // __RF24_H__
+// vim:ai:cin:sts=2 sw=2 ft=cpp
+

--- a/librf24-rpi/librf24-WiringPi/RF24_config.h
+++ b/librf24-rpi/librf24-WiringPi/RF24_config.h
@@ -1,0 +1,90 @@
+
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ */
+
+#ifndef __RF24_CONFIG_H__
+#define __RF24_CONFIG_H__
+
+
+#ifdef ARDUINO
+//#warning "Arduino enabled"
+#if ARDUINO < 100
+//#include <WProgram.h>
+#else
+//#include <Arduino.h>
+#endif
+#else 
+//#warning "Arduino disabled"
+#include "spi.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include <string.h>
+#include <sys/time.h>
+
+#define pgm_read_word(p) (*(p))
+#define pgm_read_byte(p) (*(p))
+#endif
+
+#include <stddef.h>
+
+// Stuff that is normally provided by Arduino
+//#ifdef ARDUINO
+//#include <SPI.h>
+//#else
+//#include <stdint.h>
+//#//include <stdio.h>
+//#include <string.h>
+//extern HardwareSPI SPI;
+//#define _BV(x) (1<<(x))
+
+//#else 
+//#endif
+
+//#include "../spi/spi.h"
+//#include "../gpio/gpio.h"
+
+#define _BV(x) (1<<(x))
+
+// #endif
+
+#undef SERIAL_DEBUG
+#ifdef SERIAL_DEBUG
+#define IF_SERIAL_DEBUG(x) ({x;})
+#else
+#define IF_SERIAL_DEBUG(x)
+#endif
+
+// Avoid spurious warnings
+#if 1
+#if ! defined( NATIVE ) && defined( ARDUINO )
+#undef PROGMEM
+#define PROGMEM __attribute__(( section(".progmem.data") ))
+#undef PSTR
+#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
+#endif
+#endif
+
+// Progmem is Arduino-specific
+//#ifdef ARDUINO
+//#include <avr/pgmspace.h>
+//#define PRIPSTR "%S"
+//#else
+//typedef char const char;
+typedef uint16_t prog_uint16_t;
+#define PSTR(x) (x)
+#define printf_P printf
+#define strlen_P strlen
+#define PROGMEM
+#define pgm_read_word(p) (*(p)) 
+#define PRIPSTR "%s"
+
+//#endif
+
+#endif // __RF24_CONFIG_H__
+// vim:ai:cin:sts=2 sw=2 ft=cpp

--- a/librf24-rpi/librf24-WiringPi/examples/Makefile
+++ b/librf24-rpi/librf24-WiringPi/examples/Makefile
@@ -1,0 +1,41 @@
+#############################################################################
+#
+# Makefile for librf24 examples on Raspberry Pi
+#
+# License: GPL (General Public License)
+# Author:  gnulnulf <arco@appeltaart.mine.nu>
+# Date:    2013/02/07 (version 1.0)
+#
+# Description:
+# ------------
+# use make all and make install to install the examples
+# You can change the install directory by editing the prefix line
+#
+prefix := /opt/librf24-examples
+
+# The recommended compiler flags for the Raspberry Pi
+CCFLAGS=-Wall -Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
+#CCFLAGS=
+
+# define all programs
+#PROGRAMS = scanner pingtest pongtest
+PROGRAMS = rpi-hub scanner pingtest pongtest sendto_hub
+SOURCES = ${PROGRAMS:=.cpp}
+
+all: ${PROGRAMS}
+
+${PROGRAMS}: ${SOURCES}
+#	g++ ${CCFLAGS} -Wall -L../librf24/  -lrf24 $@.cpp -o $@
+	g++ ${CCFLAGS} -L../librf24/  -lrf24 $@.cpp -o $@
+
+clean:
+	rm -rf $(PROGRAMS)
+
+install: all
+	test -d $(prefix) || mkdir $(prefix)
+	test -d $(prefix)/bin || mkdir $(prefix)/bin
+	for prog in $(PROGRAMS); do \
+	  install -m 0755 $$prog $(prefix)/bin; \
+	done
+
+.PHONY: install

--- a/librf24-rpi/librf24-WiringPi/examples/pingtest.cpp
+++ b/librf24-rpi/librf24-WiringPi/examples/pingtest.cpp
@@ -1,0 +1,243 @@
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ */
+
+/**
+ * Example RF Radio Ping Pair
+ *
+ * This is an example of how to use the RF24 class.  Write this sketch to two different nodes,
+ * connect the role_pin to ground on one.  The ping node sends the current time to the pong node,
+ * which responds by sending the value back.  The ping node can then see how long the whole cycle
+ * took.
+ */
+
+ // MODIFIED FOR WIRINGPI COMPATABILITY - jfktrey
+
+#include <cstdlib>
+#include <iostream>
+
+#include "../RF24.h"
+
+//
+// Hardware configuration
+//
+
+// Set up nRF24L01 radio on SPI bus plus pins 9 & 10
+
+//RF24 radio(9,10);
+RF24 radio("/dev/spidev0.0",8000000 , 25);  //spi device, speed and CSN,only CSN is NEEDED in RPI
+
+
+// sets the role of this unit in hardware.  Connect to GND to be the 'pong' receiver
+// Leave open to be the 'ping' transmitter
+const int role_pin = 7;
+
+//
+// Topology
+//
+
+// Radio pipe addresses for the 2 nodes to communicate.
+const uint64_t pipes[2] = { 0xF0F0F0F0E1LL, 0xF0F0F0F0D2LL };
+
+//
+// Role management
+//
+// Set up role.  This sketch uses the same software for all the nodes
+// in this system.  Doing so greatly simplifies testing.  The hardware itself specifies
+// which node it is.
+//
+// This is done through the role_pin
+//
+
+// The various roles supported by this sketch
+typedef enum { role_ping_out = 1, role_pong_back } role_e;
+
+// The debug-friendly names of those roles
+const char* role_friendly_name[] = { "invalid", "Ping out", "Pong back"};
+
+// The role of the current running sketch
+role_e role;
+
+void setup(void)
+{
+  wiringPiSetupGpio();
+  
+  //
+  // Role
+  //
+
+  // set up the role pin
+ // pinMode(role_pin, INPUT);
+  //digitalWrite(role_pin,HIGH);
+ // delay(20); // Just to get a solid reading on the role pin
+
+  // read the address pin, establish our role
+  //if ( ! digitalRead(role_pin) )
+    role = role_ping_out;
+  //else
+  //  role = role_pong_back;
+
+  //
+  // Print preamble:
+  //
+
+  //Serial.begin(115200);
+  //printf_begin();
+  printf("\n\rRF24/examples/pingpair/\n\r");
+  printf("ROLE: %s\n\r",role_friendly_name[role]);
+
+  //
+  // Setup and configure rf radio
+  //
+
+  radio.begin(WPI_MODE_GPIO);
+
+  // optionally, increase the delay between retries & # of retries
+  radio.setRetries(15,15);
+
+  // optionally, reduce the payload size.  seems to
+  // improve reliability
+//  radio.setPayloadSize(8);
+ radio.setChannel(0x4c);
+     radio.setPALevel(RF24_PA_MAX);
+
+  //
+  // Open pipes to other nodes for communication
+  //
+
+  // This simple sketch opens two pipes for these two nodes to communicate
+  // back and forth.
+  // Open 'our' pipe for writing
+  // Open the 'other' pipe for reading, in position #1 (we can have up to 5 pipes open for reading)
+
+  if ( role == role_ping_out )
+  {
+    radio.openWritingPipe(pipes[0]);
+    radio.openReadingPipe(1,pipes[1]);
+  }
+  else
+  {
+    radio.openWritingPipe(pipes[1]);
+    radio.openReadingPipe(1,pipes[0]);
+  }
+
+  //
+  // Start listening
+  //
+
+  radio.startListening();
+
+  //
+  // Dump the configuration of the rf unit for debugging
+  //
+
+  radio.printDetails();
+}
+
+void loop(void)
+{
+  //
+  // Ping out role.  Repeatedly send the current time
+  //
+
+  if (role == role_ping_out)
+  {
+    // First, stop listening so we can talk.
+    radio.stopListening();
+
+    // Take the time, and send it.  This will block until complete
+    unsigned long time = millis();
+    printf("Now sending %lu...",time);
+    bool ok = radio.write( &time, sizeof(unsigned long) );
+    
+    if (ok)
+      printf("ok...");
+    else
+      printf("failed.\n\r");
+
+    // Now, continue listening
+    radio.startListening();
+
+    // Wait here until we get a response, or timeout (250ms)
+    unsigned long started_waiting_at = millis();
+    bool timeout = false;
+    while ( ! radio.available() && ! timeout ) {
+  // by bcatalin » Thu Feb 14, 2013 11:26 am 
+  delay(5); //add a small delay to let radio.available to check payload
+      if (millis() - started_waiting_at > 200 )
+        timeout = true;
+    }
+
+    // Describe the results
+    if ( timeout )
+    {
+      printf("Failed, response timed out.\n\r");
+    }
+    else
+    {
+      // Grab the response, compare, and send to debugging spew
+      unsigned long got_time;
+      radio.read( &got_time, sizeof(unsigned long) );
+
+      // Spew it
+      printf("Got response %lu, round-trip delay: %lu\n\r",got_time,millis()-got_time);
+    }
+
+    // Try again 1s later
+//    delay(1000);
+sleep(1);
+  }
+
+  //
+  // Pong back role.  Receive each packet, dump it out, and send it back
+  //
+
+  if ( role == role_pong_back )
+  {
+    // if there is data ready
+    if ( radio.available() )
+    {
+      // Dump the payloads until we've gotten everything
+      unsigned long got_time;
+      bool done = false;
+      while (!done)
+      {
+        // Fetch the payload, and see if this was the last one.
+        done = radio.read( &got_time, sizeof(unsigned long) );
+
+        // Spew it
+        printf("Got payload %lu...",got_time);
+
+  // Delay just a little bit to let the other unit
+  // make the transition to receiver
+  delay(20);
+      }
+
+      // First, stop listening so we can talk
+      radio.stopListening();
+
+      // Send the final one back.
+      printf("Sent response.\n\r");
+      radio.write( &got_time, sizeof(unsigned long) );
+
+      // Now, resume listening so we catch the next packets.
+      radio.startListening();
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+        setup();
+        while(1)
+                loop();
+
+        return 0;
+}
+
+
+// vim:cin:ai:sts=2 sw=2 ft=cpp

--- a/librf24-rpi/librf24-WiringPi/examples/pongtest.cpp
+++ b/librf24-rpi/librf24-WiringPi/examples/pongtest.cpp
@@ -1,0 +1,244 @@
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ */
+
+/**
+ * Example RF Radio Ping Pair
+ *
+ * This is an example of how to use the RF24 class.  Write this sketch to two different nodes,
+ * connect the role_pin to ground on one.  The ping node sends the current time to the pong node,
+ * which responds by sending the value back.  The ping node can then see how long the whole cycle
+ * took.
+ */
+
+ // MODIFIED FOR WIRINGPI COMPATABILITY - jfktrey
+
+#include <cstdlib>
+#include <iostream>
+
+#include "../RF24.h"
+
+//
+// Hardware configuration
+//
+
+// Set up nRF24L01 radio on SPI bus plus pins 9 & 10
+
+//RF24 radio(9,10);
+RF24 radio("/dev/spidev0.0",8000000 , 25);  //spi device, speed and CE,only CE is NEEDED in RPI
+
+
+// sets the role of this unit in hardware.  Connect to GND to be the 'pong' receiver
+// Leave open to be the 'ping' transmitter
+const int role_pin = 7;
+
+//
+// Topology
+//
+
+// Radio pipe addresses for the 2 nodes to communicate.
+const uint64_t pipes[2] = { 0xF0F0F0F0E1LL, 0xF0F0F0F0D2LL };
+
+//
+// Role management
+//
+// Set up role.  This sketch uses the same software for all the nodes
+// in this system.  Doing so greatly simplifies testing.  The hardware itself specifies
+// which node it is.
+//
+// This is done through the role_pin
+//
+
+// The various roles supported by this sketch
+typedef enum { role_ping_out = 1, role_pong_back } role_e;
+
+// The debug-friendly names of those roles
+const char* role_friendly_name[] = { "invalid", "Ping out", "Pong back"};
+
+// The role of the current running sketch
+role_e role;
+
+void setup(void)
+{
+  wiringPiSetupGpio();
+  
+  //
+  // Role
+  //
+
+  // set up the role pin
+ // pinMode(role_pin, INPUT);
+  //digitalWrite(role_pin,HIGH);
+ // delay(20); // Just to get a solid reading on the role pin
+
+  // read the address pin, establish our role
+  //if ( ! digitalRead(role_pin) )
+  //  role = role_ping_out;
+  //else
+    role = role_pong_back;
+
+  //
+  // Print preamble:
+  //
+
+  //Serial.begin(115200);
+  //printf_begin();
+  printf("\n\rRF24/examples/pingpair/\n\r");
+  printf("ROLE: %s\n\r",role_friendly_name[role]);
+
+  //
+  // Setup and configure rf radio
+  //
+
+  radio.begin(WPI_MODE_GPIO);
+
+  // optionally, increase the delay between retries & # of retries
+  radio.setRetries(15,15);
+
+  // optionally, reduce the payload size.  seems to
+  // improve reliability
+//  radio.setPayloadSize(8);
+ radio.setChannel(0x4c);
+     radio.setPALevel(RF24_PA_LOW);
+
+  //
+  // Open pipes to other nodes for communication
+  //
+
+  // This simple sketch opens two pipes for these two nodes to communicate
+  // back and forth.
+  // Open 'our' pipe for writing
+  // Open the 'other' pipe for reading, in position #1 (we can have up to 5 pipes open for reading)
+
+  if ( role == role_ping_out )
+  {
+    radio.openWritingPipe(pipes[0]);
+    radio.openReadingPipe(1,pipes[1]);
+  }
+  else
+  {
+    radio.openWritingPipe(pipes[1]);
+    radio.openReadingPipe(1,pipes[0]);
+  }
+
+  //
+  // Start listening
+  //
+
+  radio.startListening();
+
+  //
+  // Dump the configuration of the rf unit for debugging
+  //
+
+  radio.printDetails();
+}
+
+void loop(void)
+{
+  //
+  // Ping out role.  Repeatedly send the current time
+  //
+
+  if (role == role_ping_out)
+  {
+    // First, stop listening so we can talk.
+    radio.stopListening();
+
+    // Take the time, and send it.  This will block until complete
+    unsigned long time = millis();
+    printf("Now sending %lu...",time);
+    bool ok = radio.write( &time, sizeof(unsigned long) );
+    
+    if (ok)
+      printf("ok...");
+    else
+      printf("failed.\n\r");
+
+    // Now, continue listening
+    radio.startListening();
+
+    // Wait here until we get a response, or timeout (250ms)
+    unsigned long started_waiting_at = millis();
+    bool timeout = false;
+    while ( ! radio.available() && ! timeout ) {
+        // by bcatalin » Thu Feb 14, 2013 11:26 am
+        delay(5); //add a small delay to let radio.available to check payload
+      if (millis() - started_waiting_at > 200 )
+        timeout = true;
+    }
+
+
+    // Describe the results
+    if ( timeout )
+    {
+      printf("Failed, response timed out.\n\r");
+    }
+    else
+    {
+      // Grab the response, compare, and send to debugging spew
+      unsigned long got_time;
+      radio.read( &got_time, sizeof(unsigned long) );
+
+      // Spew it
+      printf("Got response %lu, round-trip delay: %lu\n\r",got_time,millis()-got_time);
+    }
+
+    // Try again 1s later
+//    delay(1000);
+sleep(1);
+  }
+
+  //
+  // Pong back role.  Receive each packet, dump it out, and send it back
+  //
+
+  if ( role == role_pong_back )
+  {
+    // if there is data ready
+    if ( radio.available() )
+    {
+      // Dump the payloads until we've gotten everything
+      unsigned long got_time;
+      bool done = false;
+      while (!done)
+      {
+        // Fetch the payload, and see if this was the last one.
+        done = radio.read( &got_time, sizeof(unsigned long) );
+
+        // Spew it
+        printf("Got payload %lu...",got_time);
+
+  // Delay just a little bit to let the other unit
+  // make the transition to receiver
+  delay(20);
+      }
+
+      // First, stop listening so we can talk
+      radio.stopListening();
+
+      // Send the final one back.
+      printf("Sent response.\n\r");
+      radio.write( &got_time, sizeof(unsigned long) );
+
+      // Now, resume listening so we catch the next packets.
+      radio.startListening();
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+        setup();
+        while(1)
+                loop();
+
+        return 0;
+}
+
+
+// vim:cin:ai:sts=2 sw=2 ft=cpp

--- a/librf24-rpi/librf24-WiringPi/examples/rpi-hub.cpp
+++ b/librf24-rpi/librf24-WiringPi/examples/rpi-hub.cpp
@@ -1,0 +1,126 @@
+/* 
+ *
+ *  Filename : rpi-hub.cpp
+ *
+ *  This program makes the RPi as a hub listening to all six pipes from the remote 
+ *  sensor nodes ( usually Arduino  or RPi ) and will return the packet back to the 
+ *  sensor on pipe0 so that the sender can calculate the round trip delays
+ *  when the payload matches.
+ *  
+ *  Refer to RF24/examples/rpi_hub_arduino/ for the corresponding Arduino sketches 
+ * to work with this code.
+ *  
+ *  CE is connected to GPIO25
+ *  CSN is connected to GPIO8 
+ *
+ *  Refer to RPi docs for GPIO numbers
+ *
+ *  Author : Stanley Seow
+ *  e-mail : stanleyseow@gmail.com
+ *  date   : 4th Apr 2013
+ *
+ */
+
+ // MODIFIED FOR WIRINGPI COMPATABILITY - jfktrey
+
+#include <cstdlib>
+#include <iostream>
+#include "../RF24.h"
+
+using namespace std;
+
+// Radio pipe addresses for the 2 nodes to communicate.
+// First pipe is for writing, 2nd, 3rd, 4th, 5th & 6th is for reading...
+// Pipe0 in bytes is "serv1" for mirf compatibility
+const uint64_t pipes[6] = { 0x7365727631LL, 0xF0F0F0F0E1LL, 0xF0F0F0F0E2LL, 0xF0F0F0F0E3LL, 0xF0F0F0F0E4, 0xF0F0F0F0E5 };
+
+// CE and CSN pins On header using GPIO numbering (not pin numbers)
+RF24 radio("/dev/spidev0.0",8000000,25);  // Setup for GPIO 25 CSN
+
+void setup(void)
+{
+	wiringPiSetupGpio();
+
+	//
+	// Refer to RF24.h or nRF24L01 DS for settings
+	radio.begin(WPI_MODE_GPIO);
+	radio.enableDynamicPayloads();
+	radio.setAutoAck(1);
+	radio.setRetries(15,15);
+	radio.setDataRate(RF24_1MBPS);
+	radio.setPALevel(RF24_PA_MAX);
+	radio.setChannel(76);
+	radio.setCRCLength(RF24_CRC_16);
+
+	// Open 6 pipes for readings ( 5 plus pipe0, also can be used for reading )
+	radio.openWritingPipe(pipes[0]);
+	radio.openReadingPipe(1,pipes[1]);
+	radio.openReadingPipe(2,pipes[2]);
+	radio.openReadingPipe(3,pipes[3]);
+	radio.openReadingPipe(4,pipes[4]);
+	radio.openReadingPipe(5,pipes[5]);
+
+	//
+	// Dump the configuration of the rf unit for debugging
+	//
+
+	// Start Listening
+	radio.startListening();
+
+	radio.printDetails();
+	printf("\n\rOutput below : \n\r");
+	usleep(1000);
+}
+
+void loop(void)
+{
+	char receivePayload[32];
+	uint8_t pipe = 0;
+	
+
+	 while ( radio.available( &pipe ) ) {
+
+		uint8_t len = radio.getDynamicPayloadSize();
+		radio.read( receivePayload, len );
+
+		// Display it on screen
+		printf("Recv: size=%i payload=%s pipe=%i",len,receivePayload,pipe);
+
+		// Send back payload to sender
+		radio.stopListening();
+
+
+		// if pipe is 7, do not send it back
+		if ( pipe != 7 ) {
+			// Send back using the same pipe
+			// radio.openWritingPipe(pipes[pipe]);
+			radio.write(receivePayload,len);
+
+			receivePayload[len]=0;
+			printf("\t Send: size=%i payload=%s pipe:%i\n\r",len,receivePayload,pipe);
+  		} else {
+			printf("\n\r");
+                }
+
+		// Enable start listening again
+		radio.startListening();
+
+	// Increase the pipe outside the while loop
+	pipe++;
+	// reset pipe to 0
+	if ( pipe > 5 ) pipe = 0;
+	}
+
+	usleep(20);
+}
+
+
+int main(int argc, char** argv) 
+{
+	setup();
+	while(1)
+		loop();
+	
+	return 0;
+}
+

--- a/librf24-rpi/librf24-WiringPi/examples/scanner.cpp
+++ b/librf24-rpi/librf24-WiringPi/examples/scanner.cpp
@@ -1,0 +1,193 @@
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+ */
+
+/**
+ * Channel scanner
+ *
+ * Example to detect interference on the various channels available.
+ * This is a good diagnostic tool to check whether you're picking a
+ * good channel for your application.
+ *
+ * Inspired by cpixip.
+ * See http://arduino.cc/forum/index.php/topic,54795.0.html
+ */
+
+ // MODIFIED FOR WIRINGPI COMPATABILITY - jfktrey
+
+#include <cstdlib>
+#include <iostream>
+#include "../RF24.h"
+
+using namespace std;
+
+//
+// Hardware configuration
+//
+
+// Set up nRF24L01 radio on SPI bus plus pins 9 & 10
+
+// CE and CSN pins 
+//RF24 radio(8, 25);  //only CSN is NEEDED in RPI
+RF24 radio("/dev/spidev0.0",8000000 , 25);  //spi device, speed and CSN,only CSN is NEEDED in RPI
+
+//
+// Channel info
+//
+
+//const uint8_t num_channels = 128;
+const uint8_t num_channels = 120;
+uint8_t values[num_channels];
+
+//
+// Setup
+//
+
+void setup(void)
+{
+  wiringPiSetupGpio();
+
+  //
+  // Print preamble
+  //
+
+  //Serial.begin(57600);
+  //printf_begin();
+  printf("\n\rRF24/examples/scanner/\n\r");
+
+  //
+  // Setup and configure rf radio
+  //
+
+  radio.begin(WPI_MODE_GPIO);
+  radio.setAutoAck(false);
+
+  // Get into standby mode
+  radio.startListening();
+  radio.stopListening();
+
+  radio.printDetails();
+
+  // Print out header, high then low digit
+  int i = 0;
+  while ( i < num_channels )
+  {
+    printf("%x",i>>4);
+    ++i;
+  }
+  printf("\n\r");
+  i = 0;
+  while ( i < num_channels )
+  {
+    printf("%x",i&0xf);
+    ++i;
+  }
+  printf("\n\r");
+
+}
+
+//
+// Loop
+//
+/*
+const int num_reps = 100;
+
+void loop2(void)
+{
+  // Clear measurement values
+  memset(values,0,sizeof(values));
+
+  // Scan all channels num_reps times
+  int rep_counter = num_reps;
+  while (rep_counter--)
+  {
+    int i = num_channels;
+    while (i--)
+    {
+      // Select this channel
+      radio.setChannel(i);
+
+      // Listen for a little
+      radio.startListening();
+      delayMicroseconds(128);
+      radio.stopListening();
+
+      // Did we get a carrier?
+      if ( radio.testCarrier() )
+        ++values[i];
+    }
+  }
+
+  // Print out channel measurements, clamped to a single hex digit
+  int i = 0;
+  while ( i < num_channels )
+  {
+    printf("%x",min(0xf,values[i]&0xf));
+    ++i;
+  }
+  printf("\n\r");
+}
+*/
+//
+// Loop
+//
+
+const int num_reps = 100;
+
+int reset_array=0;
+
+void loop(void)
+{
+
+if ( reset_array == 1 ) { 
+  // Clear measurement values
+  memset(values,0,sizeof(values));
+  printf("\n\r");
+}
+
+  // Scan all channels num_reps times
+    int i = num_channels;
+    while (i--)
+    {
+      // Select this channel
+      radio.setChannel(i);
+
+      // Listen for a little
+      radio.startListening();
+      delayMicroseconds(128);
+      radio.stopListening();
+
+      // Did we get a carrier?
+      if ( radio.testCarrier() )
+        ++values[i];
+  if ( values[i] == 0xf ) {
+    reset_array = 2;
+  }
+    }
+
+  // Print out channel measurements, clamped to a single hex digit
+  i = 0;
+  while ( i < num_channels )
+  {
+    printf("%x",min(0xf,values[i]&0xf));
+    ++i;
+  }
+  printf("\n\r");
+}
+
+int main(int argc, char** argv)
+{
+        setup();
+        while(1)
+                loop();
+
+        return 0;
+}
+
+
+
+// vim:ai:cin:sts=2 sw=2 ft=cpp

--- a/librf24-rpi/librf24-WiringPi/examples/sendto_hub.cpp
+++ b/librf24-rpi/librf24-WiringPi/examples/sendto_hub.cpp
@@ -1,0 +1,176 @@
+/*
+ *
+ *  Filename : sendto_hub.cpp
+ *
+ * This is the client for rpi-hub.cpp or use the RPi as a client to an Arduino as a hub
+ * The first address in the pipe is for writing and the second address is for reading
+ *
+ *
+ *  Author : Stanley Seow
+ *  e-mail : stanleyseow@gmail.com
+ *  date   : 4th Apr 2013
+ *
+ */
+
+ // MODIFIED FOR WIRINGPI COMPATABILITY - jfktrey
+
+#include <cstdlib>
+#include <iostream>
+#include "../RF24.h"
+
+using namespace std;
+
+// For best performance, use P1-P5 for writing and Pipe0 for reading as per the hub setting
+// Below is the settings from the hub/receiver listening to P0 to P5
+//const uint64_t pipes[6] = { 0x7365727631LL, 0xF0F0F0F0E1LL, 0xF0F0F0F0E2LL, 0xF0F0F0F0E3LL, 0xF0F0F0F0E4LL, 0xF0F0F0F0E5LL };
+// Example below using pipe2
+const uint64_t pipes[2] = { 0xF0F0F0F0E3L, 0x7365727631LL };
+
+// CE and CSN pins On header using GPIO numbering (not pin numbers)
+RF24 radio("/dev/spidev0.0",8000000,25);  // Setup for GPIO 25 CSN
+uint8_t counter = 0;
+char receivePayload[32];
+
+
+void setup(void) {
+  wiringPiSetupGpio();
+  
+	//
+	// Refer to RF24.h or nRF24L01 DS for settings
+	radio.begin(WPI_MODE_GPIO);
+	radio.enableDynamicPayloads();
+	radio.setAutoAck(1);
+	radio.setRetries(15,15);
+	radio.setDataRate(RF24_1MBPS);
+	radio.setPALevel(RF24_PA_MAX);
+	radio.setChannel(76);
+	radio.setCRCLength(RF24_CRC_16);
+
+	// Open 6 pipes for readings ( 5 plus pipe0, also can be used for reading )
+	radio.openWritingPipe(pipes[0]);
+	radio.openReadingPipe(1,pipes[1]);
+
+	//
+	// Dump the configuration of the rf unit for debugging
+	//
+
+	radio.printDetails();
+	printf("\n\rOutput below : \n\r");
+	usleep(1000);
+}
+
+void loop(void)
+{
+
+  int Data1,Data2,Data3,Data4 = 0;
+  char temp[5];
+  bool timeout=0;
+
+  // Get the last two Bytes as node-id
+  uint16_t nodeID = pipes[0] & 0xff;
+
+  // Use the last 2 pipes address as nodeID  
+  // sprintf(nodeID,"%X",pipes[0]);
+  
+  char outBuffer[32]=""; // Clear the outBuffer before every loop
+  unsigned long send_time;
+  uint8_t rtt = 0;
+    
+    // Get readings from sensors, change codes below to read sensors
+    Data1 = counter++;
+    Data2 = rand() % 1000;
+    Data3 = rand() % 1000;
+    Data4 = rand() % 1000;
+    
+    if ( counter > 999 ) counter = 0;
+
+    // Append the hex nodeID to the beginning of the payload    
+    sprintf(outBuffer,"%2X",nodeID);
+    
+    strcat(outBuffer,",");
+    
+    // Convert int to strings and append with zeros if number smaller than 3 digits
+    // 000 to 999
+    
+    sprintf(temp,"%03d",Data1);  
+    strcat(outBuffer,temp);
+    
+    strcat(outBuffer,",");
+    
+    sprintf(temp,"%03d",Data2);
+    strcat(outBuffer,temp);
+    
+    strcat(outBuffer,",");
+
+    sprintf(temp,"%03d",Data3);
+    strcat(outBuffer,temp);
+   
+    strcat(outBuffer,",");
+   
+    sprintf(temp,"%03d",Data4);
+    strcat(outBuffer,temp); 
+
+    // Test for max payload size
+    //strcat(outBuffer,"012345678901");
+
+    
+    // End string with 0
+    // strcat(outBuffer,0);
+            
+    printf("outBuffer: %s len: %d\n\r",outBuffer, strlen(outBuffer));
+    
+    send_time = millis();
+    
+    // Stop listening and write to radio 
+    radio.stopListening();
+    
+    // Send to hub
+    if ( radio.write( outBuffer, strlen(outBuffer)) ) {
+       printf("Send successful\n\r"); 
+    }
+    else {
+       printf("Send failed\n\r");
+    }
+  
+    radio.startListening();
+    delay(20);  
+
+  while ( radio.available() && !timeout ) {
+
+         uint8_t len = radio.getDynamicPayloadSize();
+         radio.read( receivePayload, len); 
+         
+         receivePayload[len] = 0;
+         printf("inBuffer:  %s\n\r",receivePayload);
+         
+         // Compare receive payload with outBuffer        
+         if ( ! strcmp(outBuffer, receivePayload) ) {
+             rtt = millis() - send_time;
+             printf("inBuffer --> rtt: %i \n\r",rtt);       
+
+         }       
+    
+    // Check for timeout and exit the while loop
+    if ( millis() - send_time > 500 ) {
+         printf("Timeout!!!\n\r");
+         timeout = 1;
+     }          
+      
+     delay(10);
+   } // End while  
+     
+    delay(250);
+    
+}
+
+
+int main(int argc, char** argv) 
+{
+	setup();
+	while(1)
+		loop();
+	
+	return 0;
+}
+
+

--- a/librf24-rpi/librf24-WiringPi/nRF24L01.h
+++ b/librf24-rpi/librf24-WiringPi/nRF24L01.h
@@ -1,0 +1,125 @@
+/*
+    Copyright (c) 2007 Stefan Engelke <mbox@stefanengelke.de>
+
+    Permission is hereby granted, free of charge, to any person 
+    obtaining a copy of this software and associated documentation 
+    files (the "Software"), to deal in the Software without 
+    restriction, including without limitation the rights to use, copy, 
+    modify, merge, publish, distribute, sublicense, and/or sell copies 
+    of the Software, and to permit persons to whom the Software is 
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be 
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+    DEALINGS IN THE SOFTWARE.
+*/
+
+/* Memory Map */
+#define CONFIG      0x00
+#define EN_AA       0x01
+#define EN_RXADDR   0x02
+#define SETUP_AW    0x03
+#define SETUP_RETR  0x04
+#define RF_CH       0x05
+#define RF_SETUP    0x06
+#define STATUS      0x07
+#define OBSERVE_TX  0x08
+#define CD          0x09
+#define RX_ADDR_P0  0x0A
+#define RX_ADDR_P1  0x0B
+#define RX_ADDR_P2  0x0C
+#define RX_ADDR_P3  0x0D
+#define RX_ADDR_P4  0x0E
+#define RX_ADDR_P5  0x0F
+#define TX_ADDR     0x10
+#define RX_PW_P0    0x11
+#define RX_PW_P1    0x12
+#define RX_PW_P2    0x13
+#define RX_PW_P3    0x14
+#define RX_PW_P4    0x15
+#define RX_PW_P5    0x16
+#define FIFO_STATUS 0x17
+#define DYNPD	    0x1C
+#define FEATURE	    0x1D
+
+/* Bit Mnemonics */
+#define MASK_RX_DR  6
+#define MASK_TX_DS  5
+#define MASK_MAX_RT 4
+#define EN_CRC      3
+#define CRCO        2
+#define PWR_UP      1
+#define PRIM_RX     0
+#define ENAA_P5     5
+#define ENAA_P4     4
+#define ENAA_P3     3
+#define ENAA_P2     2
+#define ENAA_P1     1
+#define ENAA_P0     0
+#define ERX_P5      5
+#define ERX_P4      4
+#define ERX_P3      3
+#define ERX_P2      2
+#define ERX_P1      1
+#define ERX_P0      0
+#define AW          0
+#define ARD         4
+#define ARC         0
+#define PLL_LOCK    4
+#define RF_DR       3
+#define RF_PWR      6
+#define RX_DR       6
+#define TX_DS       5
+#define MAX_RT      4
+#define RX_P_NO     1
+#define TX_FULL     0
+#define PLOS_CNT    4
+#define ARC_CNT     0
+#define TX_REUSE    6
+#define FIFO_FULL   5
+#define TX_EMPTY    4
+#define RX_FULL     1
+#define RX_EMPTY    0
+#define DPL_P5	    5
+#define DPL_P4	    4
+#define DPL_P3	    3
+#define DPL_P2	    2
+#define DPL_P1	    1
+#define DPL_P0	    0
+#define EN_DPL	    2
+#define EN_ACK_PAY  1
+#define EN_DYN_ACK  0
+
+/* Instruction Mnemonics */
+#define R_REGISTER    0x00
+#define W_REGISTER    0x20
+#define REGISTER_MASK 0x1F
+#define ACTIVATE      0x50
+#define R_RX_PL_WID   0x60
+#define R_RX_PAYLOAD  0x61
+#define W_TX_PAYLOAD  0xA0
+#define W_ACK_PAYLOAD 0xA8
+#define FLUSH_TX      0xE1
+#define FLUSH_RX      0xE2
+#define REUSE_TX_PL   0xE3
+#define NOP           0xFF
+
+/* Non-P omissions */
+#define LNA_HCURR   0
+
+/* P model memory Map */
+#define RPD         0x09
+
+/* P model bit Mnemonics */
+#define RF_DR_LOW   5
+#define RF_DR_HIGH  3
+#define RF_PWR_LOW  1
+#define RF_PWR_HIGH 2

--- a/librf24-rpi/librf24-WiringPi/readme.md
+++ b/librf24-rpi/librf24-WiringPi/readme.md
@@ -1,0 +1,25 @@
+librf24-WiringPi
+================
+
+This version of librf24-rpi takes the vanilla GPIO version (see folder "librf24"), removes the GPIO library used there, and replaces it with WiringPi. This allows WiringPi to be used in conjunction with this library, whereas there were compatability issues before.
+
+IMPORTANT
+=========
+
+Note that there is a small difference between this version of the library and others. Because WiringPi allows you to use one of three pin numbering schemes (via wiringPiSetup, wiringPiSetupGpio/wiringPiSetupSys, and wiringPiSetupPhys), you have to pass along a constant to RF24::begin to let it know which scheme to use. Constants to use are below:
+
+**wiringPiSetup** - WPI_MODE_PINS
+**wiringPiSetupGpio** - WPI_MODE_GPIO
+**wiringPiSetupSys** - WPI_MODE_GPIO_SYS (in this library, it's implemented the same as WPI_MODE_GPIO)
+**wiringPiSetupPhys** - WPI_MODE_PHYS
+
+Existing code can be retrofitted to use this library by changing two lines:
+1. In the program initialization, call wiringPiSetupGpio();
+2. In radio.begin(), add the WPI_MODE_GPIO argument to get radio.begin(WPI_MODE_GPIO);
+
+Note that EVERY pin referenced in your code, including the CE pin you pass to the constructor, must use whatever pin numbering scheme you tell WiringPi to use.
+
+Contact
+=======
+
+Trey Keown - jfktrey@gmail.com

--- a/librf24-rpi/librf24-WiringPi/spi.cpp
+++ b/librf24-rpi/librf24-WiringPi/spi.cpp
@@ -1,0 +1,132 @@
+/* 
+ * File:   spi.cpp
+ * Author: Purinda Gunasekara <purinda@gmail.com>
+ * 
+ * Created on 24 June 2012, 11:00 AM
+ * 
+ * Inspired from spidev test in linux kernel documentation
+ * www.kernel.org/doc/Documentation/spi/spidev_test.c 
+ */
+
+#include "spi.h"
+
+SPI::SPI() {
+	
+//	this->device = "/dev/spidev0.0";;
+	this->bits = 8;
+//	this->speed = 24000000; // 24Mhz - proly doesnt work
+//	this->speed = 16000000; // 16Mhz 
+//	this->speed = 8000000; // 8Mhz 
+	this->speed = 2000000; // 2Mhz 
+	this->mode = 0;
+
+//	this->init();
+}
+
+void SPI::setbits( uint8_t bits )
+{
+ this->bits = bits;
+}
+
+void SPI::setspeed( uint32_t speed )
+{
+ this->speed = speed;
+}
+
+void SPI::setdevice( string devicefile ) 
+{
+	this->device = devicefile;
+}
+
+void SPI::init()
+{
+	int ret;
+	this->fd = open(this->device.c_str(), O_RDWR);
+	if (this->fd < 0)
+	{
+		perror("can't open device");
+		abort();
+	}
+
+	/*
+	 * spi mode
+	 */
+	ret = ioctl(this->fd, SPI_IOC_WR_MODE, &this->mode);
+	if (ret == -1)
+	{
+		perror("can't set spi mode");
+		abort();		
+	}
+
+	ret = ioctl(this->fd, SPI_IOC_RD_MODE, &this->mode);
+	if (ret == -1)
+	{
+		perror("can't set spi mode");
+		abort();				
+	}
+	
+	/*
+	 * bits per word
+	 */
+	ret = ioctl(this->fd, SPI_IOC_WR_BITS_PER_WORD, &this->bits);
+	if (ret == -1)
+	{
+		perror("can't set bits per word");
+		abort();				
+	}
+
+	ret = ioctl(this->fd, SPI_IOC_RD_BITS_PER_WORD, &this->bits);
+	if (ret == -1)
+	{
+		perror("can't set bits per word");
+		abort();						
+	}
+	/*
+	 * max speed hz
+	 */
+	ret = ioctl(this->fd, SPI_IOC_WR_MAX_SPEED_HZ, &this->speed);
+	if (ret == -1)
+	{
+		perror("can't set max speed hz");
+		abort();						
+	}
+
+	ret = ioctl(this->fd, SPI_IOC_RD_MAX_SPEED_HZ, &this->speed);
+	if (ret == -1)
+	{
+		perror("can't set max speed hz");
+		abort();						
+	}
+}
+
+uint8_t SPI::transfer(uint8_t tx_)
+{
+	int ret;
+	// One byte is transfered at once
+	uint8_t tx[] = {0};
+	tx[0] = tx_;
+
+	uint8_t rx[ARRAY_SIZE(tx)] = {0};
+	struct spi_ioc_transfer tr;
+	tr.tx_buf = (unsigned long)tx;
+	tr.rx_buf = (unsigned long)rx;
+	tr.len = ARRAY_SIZE(tx);
+	tr.delay_usecs = 0;
+//	tr.cs_change = 1;
+	tr.speed_hz = this->speed;
+	tr.bits_per_word = this->bits;
+
+	ret = ioctl(this->fd, SPI_IOC_MESSAGE(1), &tr);
+	if (ret < 1)
+	{
+		perror("can't send spi message");
+		abort();		
+	}
+
+	return rx[0];
+}
+
+SPI::~SPI() {
+	close(this->fd);
+}
+

--- a/librf24-rpi/librf24-WiringPi/spi.h
+++ b/librf24-rpi/librf24-WiringPi/spi.h
@@ -1,0 +1,53 @@
+/* 
+ * File:   spi.h
+ * Author: Purinda Gunasekara <purinda@gmail.com>
+ * 
+ * Created on 24 June 2012, 11:00 AM
+ */
+
+#ifndef SPI_H
+#define	SPI_H
+
+#include <string>
+#include <stdint.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <inttypes.h>
+#include <linux/types.h>
+#include <linux/spi/spidev.h>
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+using namespace std;
+
+class SPI {
+public:
+	
+	SPI();
+	uint8_t transfer(uint8_t tx_);
+	virtual ~SPI();
+	void init();	
+	void setdevice( string devicefile );
+	void setbits( uint8_t bits );
+	void setspeed( uint32_t speed );
+
+private:
+
+	// Default SPI device
+	string device;
+	// SPI Mode set 
+	uint8_t mode;
+	// word size
+	uint8_t bits;
+	// Set SPI speed
+	uint32_t speed;
+	int fd;
+
+};
+
+#endif	/* SPI_H */
+

--- a/librf24-rpi/readme.md
+++ b/librf24-rpi/readme.md
@@ -3,10 +3,11 @@ Raspberry Pi RF24 libraries
 
 This is the collection of libraries for RF24 / NRF24L01 wireless modules on the raspberry pi.
 
-There are two folders with two different libraries :-
+There are three folders with three different libraries :-
 
-- librf24 	 This library/driver are ported from Arduino to beaglebone then to RPi, uses GPIO
-- librf24-bcm 	 This library/driver are further ported to use Broadcom bcm2835 using hardware SPI
+- **librf24**			This library/driver is ported from Arduino to beaglebone then to RPi, uses GPIO
+- **librf24-bcm**		This library/driver is further ported to use Broadcom bcm2835 using hardware SPI
+- **librf24-wiringpi**	This library/driver implements a modified version of librf24 which uses WiringPi
 
 Setup
 =====
@@ -17,7 +18,7 @@ Setup
 
 Known issues
 ============
-- the current bcm2835 drivers still have some minor bugs/errors, if you have errors, use the GPIO version
+- The current bcm2835 drivers still have some minor bugs/errors. If you have errors, use the GPIO or WiringPi version.
 
 
 Links 
@@ -33,10 +34,14 @@ Contact
 Stanley Seow ( stanleyseow@gmail.com )
 https://github.com/stanleyseow/RF24
 
-RF24 for RPi using gpio :-
+RF24 for RPi using gpio:
 Arco van Geest <arco@appeltaart.mine.nu> 
 https://github.com/gnulnulf/RF24
 
-RF24 for RPi using bcm2835 :-
+RF24 for RPi using bcm2835:
 Charles-Henri Hallard http://hallard.me/ 
 https://github.com/hallard/RF24
+
+RF24 for RPi using WiringPi:
+Trey Keown <jfktrey@gmail.com>
+https://github.com/jfktrey/RF24


### PR DESCRIPTION
The plain GPIO version of librf24-rpi was modified to work with the WiringPi library instead of the (custom?) compatibility layer. Very useful for individuals like me who wish to use both librf24-rpi and WiringPi, but previously couldn't due to incompatibilities. WiringPi was (pretty much) a drop-in replacement for the functions used in the GPIO version.
