### PR TITLE
Examples make/compile fix

### DIFF
--- a/RPi/RF24/examples/gettingstarted.cpp
+++ b/RPi/RF24/examples/gettingstarted.cpp
@@ -24,6 +24,7 @@ TMRh20 2014 - Updated to work with optimized RF24 Arduino library
 #include <sstream>
 #include <string>
 #include <RF24/RF24.h>
+#include <unistd.h>
 
 using namespace std;
 //

--- a/RPi/RF24/examples/gettingstarted_call_response.cpp
+++ b/RPi/RF24/examples/gettingstarted_call_response.cpp
@@ -18,6 +18,7 @@ TMRh20 2014 - Updated to work with optimized RF24 Arduino library
 #include <sstream>
 #include <string>
 #include <RF24/RF24.h>
+#include <unistd.h>
 
 using namespace std;
 

--- a/RPi/RF24/examples/pingpair_dyn.cpp
+++ b/RPi/RF24/examples/pingpair_dyn.cpp
@@ -121,7 +121,8 @@ if (role == role_ping_out)
     else
     {
       // Grab the response, compare, and send to debugging spew
-      uint8_t len = radio.getDynamicPayloadSize();
+      uint8_t len = 0;
+      len = radio.getDynamicPayloadSize();
       radio.read( receive_payload, len );
 
       // Put a zero at the end for easy printing
@@ -150,7 +151,7 @@ if (role == role_ping_out)
     if ( radio.available() )
     {
       // Dump the payloads until we've gotten everything
-      uint8_t len;
+      uint8_t len = 0;
 
       while (radio.available())
       {

--- a/RPi/RF24/examples/transfer.cpp
+++ b/RPi/RF24/examples/transfer.cpp
@@ -17,6 +17,7 @@ TMRh20 2014
 #include <sstream>
 #include <string>
 #include <RF24/RF24.h>
+#include <unistd.h>
 
 
 using namespace std;


### PR DESCRIPTION
For raspberry pi library examples, added missing header file for sleep(), unistd.h.
Also changed pingpair_dyn.cpp to define variable "len" to 0 before trying to read from function. This would otherwise give me a compiler warning:

pingpair_dyn.cpp:172:42: warning: ‘len’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       radio.write( receive_payload, len );
                                          ^
